### PR TITLE
Support request bodies and reponses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 - Schemas will be generated into own namespace `Schema`
+- RequestBodies and Responses will also be generated into their own namespace
 
 ## 0.2.0
 

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -48,13 +48,20 @@ class GenerateCommand extends Command
 
         $openApiDefinition = $this->parser->parse($configuration);
 
-        $namespace = $this->classGenerator->generate($openApiDefinition, $configuration);
+        $namespaces = $this->classGenerator->generate($openApiDefinition, $configuration);
 
-        $this->classWriter->write($configuration, $namespace);
+        $this->classWriter->write($configuration, $namespaces);
 
-        $output->writeln(
-            sprintf('Wrote %u files to output path "%s"', count($namespace->getClasses()), $configuration->outputPath)
-        );
+        foreach ($namespaces as $identifier => $namespace) {
+            $output->writeln(
+                sprintf(
+                    'Wrote %u files to output path "%s" for %s',
+                    count($namespace->getClasses()),
+                    $configuration->outputPath,
+                    $identifier
+                )
+            );
+        }
 
         return self::SUCCESS;
     }

--- a/src/Exception/InvalidReferenceException.php
+++ b/src/Exception/InvalidReferenceException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class InvalidReferenceException extends Exception
+{
+    public function __construct(
+        string $referenceType,
+        string $reference,
+    ) {
+        parent::__construct(
+            sprintf('Reference of type "%s" is invalid, full reference: %s', $referenceType, $reference)
+        );
+    }
+}

--- a/src/Exception/NotRegisteredNamespaceException.php
+++ b/src/Exception/NotRegisteredNamespaceException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
+
+class NotRegisteredNamespaceException extends Exception
+{
+    public function __construct(
+        OpenApiType $openApiType
+    ) {
+        parent::__construct(
+            sprintf('No namespace is registered for open api type %s', $openApiType->value)
+        );
+    }
+}

--- a/src/Exception/UnknownMediaTypeException.php
+++ b/src/Exception/UnknownMediaTypeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class UnknownMediaTypeException extends Exception
+{
+    public function __construct(string $mediaType)
+    {
+        parent::__construct(
+            sprintf('Unknown media type "%s"', $mediaType)
+        );
+    }
+}

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -16,11 +16,22 @@ readonly class ClassGenerator
     ) {
     }
 
-    public function generate(OpenApi $openApi, Configuration $configuration): PhpNamespace
+    /**
+     * @return array<string, PhpNamespace>
+     */
+    public function generate(OpenApi $openApi, Configuration $configuration): array
+    {
+        return [
+            'schemas' => $this->addSchemas($openApi, $configuration),
+        ];
+    }
+
+    private function addSchemas(OpenApi $openApi, Configuration $configuration): PhpNamespace
     {
         $schemaNamespace = $this->buildNamespace($configuration, 'Schema');
 
         $schemas = $openApi->components->schemas ?? [];
+
         foreach ($schemas as $name => $schema) {
             if ($schema instanceof Schema) {
                 $this->classTransformer->transform($openApi, $name, $schema, $schemaNamespace);

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Generator;
 
 use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\RequestBody;
 use cebe\openapi\spec\Response;
 use cebe\openapi\spec\Schema;
@@ -55,7 +56,7 @@ readonly class ClassGenerator
     }
 
     /**
-     * @param Response[]|RequestBody[] $components
+     * @param array<RequestBody|Response|Reference> $components
      */
     private function buildMediaTypeComponents(OpenApiType $openApiType, OpenApi $openApi, array $components): void
     {
@@ -66,6 +67,10 @@ readonly class ClassGenerator
         $namespace = $this->namespaceResolver->resolveNamespace($openApiType);
 
         foreach ($components as $name => $component) {
+            if ($component instanceof Reference) {
+                continue;
+            }
+
             $hasMultipleMediaTypes = count($component->content) > 1;
 
             foreach ($component->content as $mediaTypeName => $mediaType) {

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -32,7 +32,7 @@ readonly class ClassTransformer
 
         foreach ($schemasForClass as $schema) {
             foreach ($schema->properties as $propertyName => $property) {
-                $type = $this->typeResolver->resolve($openApi, $property, $namespace);
+                $type = $this->typeResolver->resolve($openApi, $property);
 
                 $parameter = $this->propertyResolver->resolve(
                     $constructor,
@@ -143,7 +143,7 @@ readonly class ClassTransformer
             return;
         }
 
-        $arrayType = $this->typeResolver->resolve($openApi, $itemsSchema, $namespace);
+        $arrayType = $this->typeResolver->resolve($openApi, $itemsSchema);
 
         if ($arrayType === Types::Object && $itemsSchema instanceof Schema) {
             $arrayType = $namespace->resolveName(
@@ -198,7 +198,7 @@ readonly class ClassTransformer
 
         foreach ($oneOf as $oneOfElement) {
             if ($oneOfElement instanceof Schema) {
-                $resolvedType = $this->typeResolver->resolve($openApi, $oneOfElement, $namespace);
+                $resolvedType = $this->typeResolver->resolve($openApi, $oneOfElement);
 
                 $resolvedTypes[] = match ($resolvedType) {
                     Types::Object => $namespace->resolveName(
@@ -226,7 +226,7 @@ readonly class ClassTransformer
             }
 
             if ($oneOfElement instanceof Reference) {
-                $resolvedTypes[] = $this->typeResolver->resolve($openApi, $oneOfElement, $namespace);
+                $resolvedTypes[] = $this->typeResolver->resolve($openApi, $oneOfElement);
             }
         }
 

--- a/src/Generator/NamespaceResolver.php
+++ b/src/Generator/NamespaceResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Generator;
+
+use Nette\PhpGenerator\PhpNamespace;
+use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Exception\NotRegisteredNamespaceException;
+
+class NamespaceResolver
+{
+    /**
+     * @var array<value-of<OpenApiType>, PhpNamespace>
+     */
+    private array $openApiTypeToNamespace = [];
+
+    /**
+     * @return array<value-of<OpenApiType>, PhpNamespace>
+     */
+    public function getNamespaces(): array
+    {
+        return $this->openApiTypeToNamespace;
+    }
+
+    public function resolveNamespace(OpenApiType $openApiType): PhpNamespace
+    {
+        $namespace = $this->openApiTypeToNamespace[$openApiType->value] ?? null;
+
+        if ($namespace === null) {
+            throw new NotRegisteredNamespaceException($openApiType);
+        }
+
+        return $namespace;
+    }
+
+    public function initialize(Configuration $configuration): void
+    {
+        foreach (OpenApiType::cases() as $openApiType) {
+            $this->openApiTypeToNamespace[$openApiType->value] = $this->buildNamespace($configuration, $openApiType);
+        }
+    }
+
+    private function buildNamespace(Configuration $configuration, OpenApiType $openApiType): PhpNamespace
+    {
+        if (strlen($configuration->namespace) === 0) {
+            return new PhpNamespace($this->mapOpenApiTypeToNamespace($openApiType));
+        }
+
+        return new PhpNamespace(sprintf(
+            '%s\%s',
+            $configuration->namespace,
+            $this->mapOpenApiTypeToNamespace($openApiType)
+        ));
+    }
+
+    private function mapOpenApiTypeToNamespace(OpenApiType $type): string
+    {
+        return match ($type) {
+            OpenApiType::Schemas => 'Schema',
+            OpenApiType::RequestBodies => 'RequestBody',
+            OpenApiType::Responses => 'Response',
+        };
+    }
+}

--- a/src/Generator/OpenApiType.php
+++ b/src/Generator/OpenApiType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Reinfi\OpenApiModels\Generator;
 
-enum OpenApiType
+enum OpenApiType: string
 {
-    case Schemas;
-    case RequestBodies;
-    case Responses;
+    case Schemas = 'schemas';
+    case RequestBodies = 'requestBodies';
+    case Responses = 'responses';
 }

--- a/src/Generator/OpenApiType.php
+++ b/src/Generator/OpenApiType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Generator;
+
+enum OpenApiType
+{
+    case Schemas;
+    case RequestBodies;
+    case Responses;
+}

--- a/src/Generator/ReferenceResolver.php
+++ b/src/Generator/ReferenceResolver.php
@@ -27,13 +27,16 @@ readonly class ReferenceResolver
 
         $openApiType = OpenApiType::tryFrom($matches['type']);
 
+        if ($openApiType === null) {
+            throw new InvalidReferenceException($matches['type'], $reference->getReference());
+        }
+
         $schema = match ($openApiType) {
             OpenApiType::Schemas => $openApi->components->schemas[$matches['name']] ?? null,
             OpenApiType::Responses, OpenApiType::RequestBodies => throw new InvalidReferenceException(
                 $openApiType->value,
                 $reference->getReference(),
             ),
-            default => throw new InvalidReferenceException($matches['type'], $reference->getReference())
         };
 
         if ($schema instanceof Schema) {

--- a/src/Generator/ReferenceResolver.php
+++ b/src/Generator/ReferenceResolver.php
@@ -8,6 +8,7 @@ use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use InvalidArgumentException;
+use Reinfi\OpenApiModels\Exception\InvalidReferenceException;
 use Reinfi\OpenApiModels\Model\SchemaWithName;
 
 readonly class ReferenceResolver
@@ -15,7 +16,7 @@ readonly class ReferenceResolver
     public function resolve(OpenApi $openApi, Reference $reference): SchemaWithName
     {
         if (preg_match(
-            '/^(?<fileOrUrl>[^#]+)?#\/components\/schemas\/(?<name>.+)$/',
+            '/^(?<fileOrUrl>[^#]+)?#\/components\/(?<type>.+)\/(?<name>.+)$/',
             $reference->getReference(),
             $matches
         ) !== 1) {
@@ -24,10 +25,19 @@ readonly class ReferenceResolver
             );
         }
 
-        $schema = $openApi->components->schemas[$matches['name']] ?? null;
+        $openApiType = OpenApiType::tryFrom($matches['type']);
+
+        $schema = match ($openApiType) {
+            OpenApiType::Schemas => $openApi->components->schemas[$matches['name']] ?? null,
+            OpenApiType::Responses, OpenApiType::RequestBodies => throw new InvalidReferenceException(
+                $openApiType->value,
+                $reference->getReference(),
+            ),
+            default => throw new InvalidReferenceException($matches['type'], $reference->getReference())
+        };
 
         if ($schema instanceof Schema) {
-            return new SchemaWithName($matches['name'], $schema);
+            return new SchemaWithName($openApiType, $matches['name'], $schema);
         }
 
         throw new InvalidArgumentException(sprintf('Can not resolve reference "%s"', $reference->getReference()));

--- a/src/Generator/TypeResolver.php
+++ b/src/Generator/TypeResolver.php
@@ -8,22 +8,26 @@ use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use InvalidArgumentException;
-use Nette\PhpGenerator\PhpNamespace;
 
 readonly class TypeResolver
 {
     public function __construct(
-        private ReferenceResolver $referenceResolver
+        private ReferenceResolver $referenceResolver,
+        private NamespaceResolver $namespaceResolver,
     ) {
     }
 
     /**
      * @return ($schema is Reference ? string : string|Types)
      */
-    public function resolve(OpenApi $openApi, Schema|Reference $schema, PhpNamespace $namespace): string|Types
+    public function resolve(OpenApi $openApi, Schema|Reference $schema): string|Types
     {
         if ($schema instanceof Reference) {
-            return $namespace->resolveName($this->referenceResolver->resolve($openApi, $schema)->name);
+            $schemaWithName = $this->referenceResolver->resolve($openApi, $schema);
+
+            return $this->namespaceResolver->resolveNamespace($schemaWithName->openApiType)->resolveName(
+                $schemaWithName->name
+            );
         }
 
         if (is_array($schema->oneOf) && count($schema->oneOf) > 0) {

--- a/src/Model/SchemaWithName.php
+++ b/src/Model/SchemaWithName.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Model;
 
 use cebe\openapi\spec\Schema;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
 
 readonly class SchemaWithName
 {
     public function __construct(
+        public OpenApiType $openApiType,
         public string $name,
         public Schema $schema
     ) {

--- a/src/Writer/ClassWriter.php
+++ b/src/Writer/ClassWriter.php
@@ -17,39 +17,44 @@ readonly class ClassWriter
     ) {
     }
 
-    public function write(Configuration $configuration, PhpNamespace $namespace): void
+    /**
+     * @param array<string, PhpNamespace> $namespaces
+     */
+    public function write(Configuration $configuration, array $namespaces): void
     {
         if ($configuration->clearOutputDirectory) {
             $this->clearOutputDirectory($configuration->outputPath);
         }
 
-        foreach ($namespace->getClasses() as $class) {
-            if ($class->getName() === null) {
-                continue;
-            }
+        foreach ($namespaces as $namespace) {
+            foreach ($namespace->getClasses() as $class) {
+                if ($class->getName() === null) {
+                    continue;
+                }
 
-            $namespaceShortName = Helpers::extractShortName($namespace->getName());
-            $outputDirectoryWithNamespace = sprintf('%s/%s', $configuration->outputPath, $namespaceShortName);
+                $namespaceShortName = Helpers::extractShortName($namespace->getName());
+                $outputDirectoryWithNamespace = sprintf('%s/%s', $configuration->outputPath, $namespaceShortName);
 
-            if (! is_dir($outputDirectoryWithNamespace)) {
-                mkdir($outputDirectoryWithNamespace);
-            }
+                if (! is_dir($outputDirectoryWithNamespace)) {
+                    mkdir($outputDirectoryWithNamespace);
+                }
 
-            $filePath = sprintf('%s/%s.php', $outputDirectoryWithNamespace, $class->getName());
+                $filePath = sprintf('%s/%s.php', $outputDirectoryWithNamespace, $class->getName());
 
-            $classOnlyNamespace = new PhpNamespace($namespace->getName());
-            $classOnlyNamespace->add($class);
+                $classOnlyNamespace = new PhpNamespace($namespace->getName());
+                $classOnlyNamespace->add($class);
 
-            file_put_contents(
-                $filePath,
-                <<<TPL
+                file_put_contents(
+                    $filePath,
+                    <<<TPL
                 <?php
 
                 declare(strict_types=1);
 
                 {$this->printer->printNamespace($classOnlyNamespace)}
                 TPL
-            );
+                );
+            }
         }
     }
 

--- a/test/Acceptance/AcceptanceTest.php
+++ b/test/Acceptance/AcceptanceTest.php
@@ -29,5 +29,13 @@ class AcceptanceTest extends TestCase
             __DIR__ . '/ExpectedClasses/Test6States.php',
             __DIR__ . '/../output/Schema/Test6States.php'
         );
+        self::assertFileEquals(
+            __DIR__ . '/ExpectedClasses/RequestBody1.php',
+            __DIR__ . '/../output/RequestBody/RequestBody1.php'
+        );
+        self::assertFileEquals(
+            __DIR__ . '/ExpectedClasses/Response1.php',
+            __DIR__ . '/../output/Response/Response1.php'
+        );
     }
 }

--- a/test/Acceptance/ExpectedClasses/RequestBody1.php
+++ b/test/Acceptance/ExpectedClasses/RequestBody1.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\RequestBody;
+
+readonly class RequestBody1
+{
+    public function __construct(
+        public string $id,
+        public ?\Api\Schema\Test1 $test = null,
+    ) {
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Response1.php
+++ b/test/Acceptance/ExpectedClasses/Response1.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Response;
+
+readonly class Response1
+{
+    public function __construct(
+        public string $id,
+        public ?\Api\Schema\Test1 $test = null,
+    ) {
+    }
+}

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Configuration\Configuration;
 use Reinfi\OpenApiModels\Generator\ClassGenerator;
 use Reinfi\OpenApiModels\Generator\ClassTransformer;
+use Reinfi\OpenApiModels\Generator\NamespaceResolver;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
 
 class ClassGeneratorTest extends TestCase
 {
@@ -23,6 +25,7 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesClassesFromOpenApi(): void
     {
         $configuration = new Configuration([], '', '', false);
+        $namespace = new PhpNamespace('Schema');
 
         $openApi = new OpenApi([
             'components' => [
@@ -45,48 +48,24 @@ class ClassGeneratorTest extends TestCase
             $openApi,
             $this->callback(static fn (string $name): bool => in_array($name, ['Test1', 'Test2'], true)),
             $this->isInstanceOf(Schema::class),
-            $this->callback(static fn (PhpNamespace $namespace): bool => $namespace->getName() === 'Schema')
+            $namespace
         );
 
-        $generator = new ClassGenerator($transformer);
-
-        $namespaces = $generator->generate($openApi, $configuration);
-
-        self::assertCount(3, $namespaces);
-    }
-
-    public function testItGeneratesClassesFromOpenApiWithNamespace(): void
-    {
-        $configuration = new Configuration([], '', 'Api', false);
-
-        $openApi = new OpenApi([
-            'components' => [
-                'schemas' => [
-                    'Test1' => [
-                        'type' => 'object',
-                    ],
-                ],
-            ],
-        ]);
-
-        $transformer = $this->createMock(ClassTransformer::class);
-        $transformer->expects($this->once())->method('transform')->with(
-            $openApi,
-            'Test1',
-            $this->isInstanceOf(Schema::class),
-            $this->callback(static fn (PhpNamespace $namespace): bool => $namespace->getName() === 'Api\Schema')
+        $namespaceResolver = $this->createMock(NamespaceResolver::class);
+        $namespaceResolver->expects($this->once())->method('initialize')->with($configuration);
+        $namespaceResolver->expects($this->once())->method('resolveNamespace')->with(OpenApiType::Schemas)->willReturn(
+            $namespace
         );
 
-        $generator = new ClassGenerator($transformer);
+        $generator = new ClassGenerator($transformer, $namespaceResolver);
 
-        $namespaces = $generator->generate($openApi, $configuration);
-
-        self::assertCount(3, $namespaces);
+        $generator->generate($openApi, $configuration);
     }
 
     public function testItGeneratesRequestBodies(): void
     {
         $configuration = new Configuration([], '', '', false);
+        $namespace = new PhpNamespace('RequestBody');
 
         $openApi = new OpenApi([
             'components' => [
@@ -109,19 +88,24 @@ class ClassGeneratorTest extends TestCase
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),
-            $this->callback(static fn (PhpNamespace $namespace): bool => $namespace->getName() === 'RequestBody')
+            $namespace
         );
 
-        $generator = new ClassGenerator($transformer);
+        $namespaceResolver = $this->createMock(NamespaceResolver::class);
+        $namespaceResolver->expects($this->once())->method('initialize')->with($configuration);
+        $namespaceResolver->expects($this->once())->method('resolveNamespace')->with(
+            OpenApiType::RequestBodies
+        )->willReturn($namespace);
 
-        $namespaces = $generator->generate($openApi, $configuration);
+        $generator = new ClassGenerator($transformer, $namespaceResolver);
 
-        self::assertCount(3, $namespaces);
+        $generator->generate($openApi, $configuration);
     }
 
     public function testItGeneratesResponses(): void
     {
         $configuration = new Configuration([], '', '', false);
+        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -144,19 +128,24 @@ class ClassGeneratorTest extends TestCase
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),
-            $this->callback(static fn (PhpNamespace $namespace): bool => $namespace->getName() === 'Response')
+            $namespace
         );
 
-        $generator = new ClassGenerator($transformer);
+        $namespaceResolver = $this->createMock(NamespaceResolver::class);
+        $namespaceResolver->expects($this->once())->method('initialize')->with($configuration);
+        $namespaceResolver->expects($this->once())->method('resolveNamespace')->with(
+            OpenApiType::Responses
+        )->willReturn($namespace);
 
-        $namespaces = $generator->generate($openApi, $configuration);
+        $generator = new ClassGenerator($transformer, $namespaceResolver);
 
-        self::assertCount(3, $namespaces);
+        $generator->generate($openApi, $configuration);
     }
 
     public function testItAppendsSuffixOnMultipleMediaTypes(): void
     {
         $configuration = new Configuration([], '', '', false);
+        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -184,13 +173,17 @@ class ClassGeneratorTest extends TestCase
             $openApi,
             $this->callback(static fn (string $name): bool => in_array($name, ['Test1Json', 'Test1Xml'], true)),
             $this->isInstanceOf(Schema::class),
-            $this->callback(static fn (PhpNamespace $namespace): bool => $namespace->getName() === 'Response')
+            $namespace
         );
 
-        $generator = new ClassGenerator($transformer);
+        $namespaceResolver = $this->createMock(NamespaceResolver::class);
+        $namespaceResolver->expects($this->once())->method('initialize')->with($configuration);
+        $namespaceResolver->expects($this->once())->method('resolveNamespace')->with(
+            OpenApiType::Responses
+        )->willReturn($namespace);
 
-        $namespaces = $generator->generate($openApi, $configuration);
+        $generator = new ClassGenerator($transformer, $namespaceResolver);
 
-        self::assertCount(3, $namespaces);
+        $generator->generate($openApi, $configuration);
     }
 }

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -50,7 +50,9 @@ class ClassGeneratorTest extends TestCase
 
         $generator = new ClassGenerator($transformer);
 
-        $generator->generate($openApi, $configuration);
+        $namespaces = $generator->generate($openApi, $configuration);
+
+        self::assertCount(1, $namespaces);
     }
 
     public function testItGeneratesClassesFromOpenApiWithNamespace(): void
@@ -77,6 +79,8 @@ class ClassGeneratorTest extends TestCase
 
         $generator = new ClassGenerator($transformer);
 
-        $generator->generate($openApi, $configuration);
+        $namespaces = $generator->generate($openApi, $configuration);
+
+        self::assertCount(1, $namespaces);
     }
 }

--- a/test/Generator/ClassTransformerTest.php
+++ b/test/Generator/ClassTransformerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Exception\UnresolvedArrayTypeException;
 use Reinfi\OpenApiModels\Exception\UnsupportedTypeForOneOfException;
 use Reinfi\OpenApiModels\Generator\ClassTransformer;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
 use Reinfi\OpenApiModels\Generator\PropertyResolver;
 use Reinfi\OpenApiModels\Generator\ReferenceResolver;
 use Reinfi\OpenApiModels\Generator\TypeResolver;
@@ -42,7 +43,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn('int', 'string');
 
         $transformer = new ClassTransformer($propertyResolver, $typeResolver, $referenceResolver);
@@ -77,6 +77,7 @@ class ClassTransformerTest extends TestCase
             static fn (Reference $reference): bool => $reference->getReference() === '#/components/schemas/Test2'
         ))->willReturn(
             new SchemaWithName(
+                OpenApiType::Schemas,
                 'Test2',
                 new Schema([
                     'properties' => [
@@ -91,7 +92,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn('int', 'string');
 
         $transformer = new ClassTransformer($propertyResolver, $typeResolver, $referenceResolver);
@@ -132,7 +132,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Object, 'string');
 
         $transformer = new ClassTransformer($propertyResolver, $typeResolver, $referenceResolver);
@@ -172,7 +171,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->once())->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Enum);
 
         $transformer = new ClassTransformer($propertyResolver, $typeResolver, $referenceResolver);
@@ -217,7 +215,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->once())->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Enum);
 
         $transformer = new ClassTransformer($propertyResolver, $typeResolver, $referenceResolver);
@@ -263,7 +260,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->once())->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array);
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -302,7 +298,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->once())->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array);
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -344,7 +339,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array, Types::AnyOf);
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -386,7 +380,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array, 'string');
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -429,7 +422,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array, 'string');
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -473,7 +465,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(3))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array, Types::Object, 'string');
 
         $propertyResolver->expects($this->exactly(2))->method('resolve')->willReturn($arrayParameter, $objectParameter);
@@ -521,7 +512,6 @@ class ClassTransformerTest extends TestCase
         $typeResolver->expects($this->exactly(2))->method('resolve')->with(
             $openApi,
             $this->isInstanceOf(Schema::class),
-            $namespace
         )->willReturn(Types::Array, Types::Enum);
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($arrayParameter);
@@ -571,7 +561,6 @@ class ClassTransformerTest extends TestCase
 
                 return true;
             }),
-            $namespace
         )->willReturn(Types::Array, 'Test2');
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -626,7 +615,6 @@ class ClassTransformerTest extends TestCase
 
                 return $schema->type === 'array';
             }),
-            $namespace
         )->willReturn(Types::Array, Types::OneOf, 'Test1', 'Test2');
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -689,7 +677,6 @@ class ClassTransformerTest extends TestCase
 
                 return $schema->type === 'array';
             }),
-            $namespace
         )->willReturn(Types::Array, Types::OneOf, 'Test1', 'Test2');
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
@@ -749,7 +736,6 @@ class ClassTransformerTest extends TestCase
 
                 return in_array($schema->type, ['object', 'string'], true);
             }),
-            $namespace
         )->willReturn(Types::OneOf, Types::Object, 'string', 'Test2');
 
         $propertyResolver->expects($this->exactly(2))->method('resolve')->willReturn($referenceParameter, $idParameter);
@@ -809,7 +795,6 @@ class ClassTransformerTest extends TestCase
 
                 return $schema->type === 'array';
             }),
-            $namespace
         )->willReturn(Types::OneOf, Types::Array);
 
         $propertyResolver->expects($this->once())->method('resolve')->willReturn($referenceParameter);

--- a/test/Generator/NamespaceResolverTest.php
+++ b/test/Generator/NamespaceResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Test\Generator;
+
+use Nette\PhpGenerator\PhpNamespace;
+use PHPUnit\Framework\TestCase;
+use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Exception\NotRegisteredNamespaceException;
+use Reinfi\OpenApiModels\Generator\NamespaceResolver;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
+
+class NamespaceResolverTest extends TestCase
+{
+    public static function ResolveNamespaceDataProvider(): iterable
+    {
+        yield [
+            'openApiType' => OpenApiType::Schemas,
+            'configurationNamespace' => '',
+            'expectedNamespace' => 'Schema',
+        ];
+        yield [
+            'openApiType' => OpenApiType::RequestBodies,
+            'configurationNamespace' => '',
+            'expectedNamespace' => 'RequestBody',
+        ];
+        yield [
+            'openApiType' => OpenApiType::Responses,
+            'configurationNamespace' => '',
+            'expectedNamespace' => 'Response',
+        ];
+        yield [
+            'openApiType' => OpenApiType::Schemas,
+            'configurationNamespace' => 'Api',
+            'expectedNamespace' => 'Api\Schema',
+        ];
+        yield [
+            'openApiType' => OpenApiType::RequestBodies,
+            'configurationNamespace' => 'Api',
+            'expectedNamespace' => 'Api\RequestBody',
+        ];
+        yield [
+            'openApiType' => OpenApiType::Responses,
+            'configurationNamespace' => 'Api',
+            'expectedNamespace' => 'Api\Response',
+        ];
+    }
+
+    public function testItInitializesNamespacesFromConfiguration(): void
+    {
+        $configuration = new Configuration([], '', '', false);
+
+        $resolver = new NamespaceResolver();
+
+        $resolver->initialize($configuration);
+
+        $namespaces = $resolver->getNamespaces();
+
+        self::assertCount(3, $namespaces);
+        self::assertContainsOnlyInstancesOf(PhpNamespace::class, $namespaces);
+        self::assertArrayHasKey(OpenApiType::Schemas->value, $namespaces);
+        self::assertArrayHasKey(OpenApiType::RequestBodies->value, $namespaces);
+        self::assertArrayHasKey(OpenApiType::Responses->value, $namespaces);
+    }
+
+    /**
+     * @dataProvider ResolveNamespaceDataProvider
+     */
+    public function testItResolvesNamespace(
+        OpenApiType $openApiType,
+        string $configurationNamespace,
+        string $expectedNameSpace
+    ): void {
+        $configuration = new Configuration([], '', $configurationNamespace, false);
+
+        $resolver = new NamespaceResolver();
+
+        $resolver->initialize($configuration);
+
+        $namespace = $resolver->resolveNamespace($openApiType);
+
+        self::assertEquals($expectedNameSpace, $namespace->getName());
+    }
+
+    public function testItThrowsExceptionIfNamespaceNotKnown(): void
+    {
+        self::expectException(NotRegisteredNamespaceException::class);
+        self::expectExceptionMessage('No namespace is registered for open api type schemas');
+
+        $resolver = new NamespaceResolver();
+
+        $resolver->resolveNamespace(OpenApiType::Schemas);
+    }
+}

--- a/test/Generator/ReferenceResolverTest.php
+++ b/test/Generator/ReferenceResolverTest.php
@@ -8,6 +8,8 @@ use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Reference;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Reinfi\OpenApiModels\Exception\InvalidReferenceException;
+use Reinfi\OpenApiModels\Generator\OpenApiType;
 use Reinfi\OpenApiModels\Generator\ReferenceResolver;
 
 class ReferenceResolverTest extends TestCase
@@ -48,6 +50,7 @@ class ReferenceResolverTest extends TestCase
         $resolver = new ReferenceResolver();
 
         self::assertEquals($expectedName, $resolver->resolve($openApi, $reference)->name);
+        self::assertEquals(OpenApiType::Schemas, $resolver->resolve($openApi, $reference)->openApiType);
     }
 
     public function testItThrowsExceptionIfNotValidReference(): void
@@ -58,6 +61,22 @@ class ReferenceResolverTest extends TestCase
         $openApi = new OpenApi([]);
         $reference = new Reference([
             '$ref' => 'no-valid-reference',
+        ]);
+
+        $resolver = new ReferenceResolver();
+        $resolver->resolve($openApi, $reference);
+    }
+
+    public function testItThrowsExceptionIfTypeIsNotValid(): void
+    {
+        self::expectException(InvalidReferenceException::class);
+        self::expectExceptionMessage(
+            'Reference of type "responses" is invalid, full reference: #/components/responses/ResponseInvalid'
+        );
+
+        $openApi = new OpenApi([]);
+        $reference = new Reference([
+            '$ref' => '#/components/responses/ResponseInvalid',
         ]);
 
         $resolver = new ReferenceResolver();

--- a/test/Writer/ClassWriterTest.php
+++ b/test/Writer/ClassWriterTest.php
@@ -26,19 +26,23 @@ class ClassWriterTest extends TestCase
 
     public function testItWritesClasses(): void
     {
-        $printer = $this->createConfiguredMock(PsrPrinter::class, [
-            'printNamespace' => 'here comes class contents',
-        ]);
+        $printer = $this->createMock(PsrPrinter::class);
+        $printer->expects($this->exactly(2))->method('printNamespace')->willReturn('here comes class contents');
 
         $writer = new ClassWriter($printer);
 
         $configuration = new Configuration([], $this->outputDir->url(), '', false);
 
-        $namespace = new PhpNamespace($configuration->namespace);
-        $namespace->addClass('ClassFirst');
-        $namespace->addClass('ClassSecond');
+        $firstNamespace = new PhpNamespace('Schema');
+        $firstNamespace->addClass('ClassFirst');
 
-        $writer->write($configuration, $namespace);
+        $secondNamespace = new PhpNamespace('Response');
+        $secondNamespace->addClass('ClassSecond');
+
+        $writer->write($configuration, [
+            'schemas' => $firstNamespace,
+            'responses' => $secondNamespace,
+        ]);
 
         self::assertCount(2, $this->outputDir->getChildren());
     }

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -103,3 +103,33 @@ components:
             enum:
               - positive
               - negative
+
+  requestBodies:
+    RequestBody1:
+      description: Test
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                type: string
+              test:
+                $ref: '#/components/schemas/Test1'
+
+  responses:
+    Response1:
+      description: Test
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                type: string
+              test:
+                $ref: '#/components/schemas/Test1'


### PR DESCRIPTION
Requires update of https://github.com/marcelthole/openapi-merge/pull/41 to work with multiple input files. 

Now requestBodies and responses are supported and will be generated into their own namespace. 

Imports are resolved when from schemas section. It is not allowed to reference in the schemas section to requestBodies or responses as that would not work with media type resolution. 