### PR TITLE
add support for date and date-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Schemas will be generated into own namespace `Schema`
 - RequestBodies and Responses will also be generated into their own namespace
+- date and date-time are supported, by default it is disabled and will be transformed into `string`.
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,38 @@ return [
     'outputPath' => __DIR__ . '/output', # output directory
     'namespace' => 'Api', # namespace for generated classes, can be empty
     'clearOutputDirectory' => true, # to remove all files in output directory, default is false
+    'dateTimeAsObject' => false, # date/date-time definition will be `string` otherwise `DateTimeInterface`.
 ];
 ```
 
 If you like to store your configuration somewhere else you need to provide the file name to the command.
 
 `php vendor/bin/openapi-models generate --config spec/openapi-models.php`
+
+## Date or DateTime
+
+The following schema has date/date-time properties.
+
+```yml
+components:
+  schemas:
+    Test1:
+      type: object
+      required:
+        - date
+      properties:
+        date:
+          type: string
+          format: date
+        dateTime:
+          type: string
+          format: date-time
+```
+
+The default is to generate the fields as `string`-type because this would not require
+any logic for serialization of the class. 
+
+You can change the configuration `dateTimeAsObject` to `true` and then these fields will be of type `DateTimeInterface`. 
+
+A serialization function is added to these classes to support native `json_encode`. If you do not use native json_encode you 
+may need to provide an own implementation to fulfill open api specifications. 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -11,7 +11,8 @@ readonly class Configuration
         public array $paths,
         public string $outputPath,
         public string $namespace,
-        public bool $clearOutputDirectory
+        public bool $clearOutputDirectory,
+        public bool $dateTimeAsObject,
     ) {
     }
 }

--- a/src/Configuration/ConfigurationBuilder.php
+++ b/src/Configuration/ConfigurationBuilder.php
@@ -33,6 +33,7 @@ readonly class ConfigurationBuilder
             $configurationValues['outputPath'] ?? '',
             $configurationValues['namespace'] ?? '',
             (bool) ($configurationValues['clearOutputDirectory'] ?? false),
+            (bool) ($configurationValues['dateTimeAsObject'] ?? false),
         );
 
         $this->validate($configuration);

--- a/src/Exception/InvalidDateFormatException.php
+++ b/src/Exception/InvalidDateFormatException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class InvalidDateFormatException extends Exception
+{
+    public function __construct(
+        string $propertyName
+    ) {
+        parent::__construct(
+            sprintf('Invalid date format found for property "%s"', $propertyName)
+        );
+    }
+}

--- a/src/Exception/PropertyNotFoundException.php
+++ b/src/Exception/PropertyNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class PropertyNotFoundException extends Exception
+{
+    public function __construct(
+        string $propertyName
+    ) {
+        parent::__construct(sprintf('Property "%s" was not found in schema', $propertyName));
+    }
+}

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -305,7 +305,8 @@ readonly class ClassTransformer
                             $namespace
                         )
                     ),
-                    Types::OneOf, Types::AnyOf, Types::Array => throw new UnsupportedTypeForOneOfException(
+
+                    Types::Date, Types::DateTime, Types::OneOf, Types::AnyOf, Types::Array => throw new UnsupportedTypeForOneOfException(
                         $resolvedType->value
                     ),
                     default => $resolvedType,

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -7,9 +7,11 @@ namespace Reinfi\OpenApiModels\Generator;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
+use DateTimeInterface;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\PromotedParameter;
+use Reinfi\OpenApiModels\Configuration\Configuration;
 use Reinfi\OpenApiModels\Exception\UnresolvedArrayTypeException;
 use Reinfi\OpenApiModels\Exception\UnsupportedTypeForOneOfException;
 
@@ -19,10 +21,12 @@ readonly class ClassTransformer
         private PropertyResolver $propertyResolver,
         private TypeResolver $typeResolver,
         private ReferenceResolver $referenceResolver,
+        private SerializableResolver $serializableResolver,
     ) {
     }
 
     public function transform(
+        Configuration $configuration,
         OpenApi $openApi,
         string $name,
         Schema|Reference $schema,
@@ -58,8 +62,24 @@ readonly class ClassTransformer
                     $namespace->addUse($type->name);
                 }
 
+                if ($type === Types::Date || $type === Types::DateTime) {
+                    if ($configuration->dateTimeAsObject) {
+                        $namespace->addUse(DateTimeInterface::class);
+                        $parameter->setType(DateTimeInterface::class);
+                    } else {
+                        $parameter->setType('string');
+                    }
+                }
+
                 if ($type === Types::Object && $property instanceof Schema) {
-                    $inlineType = $this->transformInlineObject($openApi, $name, $propertyName, $property, $namespace);
+                    $inlineType = $this->transformInlineObject(
+                        $configuration,
+                        $openApi,
+                        $name,
+                        $propertyName,
+                        $property,
+                        $namespace
+                    );
 
                     $parameter->setType($namespace->resolveName($inlineType));
                 }
@@ -71,15 +91,34 @@ readonly class ClassTransformer
                 }
 
                 if ($type === Types::Array && $property instanceof Schema) {
-                    $this->resolveArrayType($openApi, $name, $propertyName, $property, $namespace, $parameter);
+                    $this->resolveArrayType(
+                        $configuration,
+                        $openApi,
+                        $name,
+                        $propertyName,
+                        $property,
+                        $namespace,
+                        $parameter
+                    );
                 }
 
                 if ($type === Types::OneOf && $property instanceof Schema) {
-                    $oneOfType = $this->transformOneOf($openApi, $name, $propertyName, $property->oneOf, $namespace);
+                    $oneOfType = $this->transformOneOf(
+                        $configuration,
+                        $openApi,
+                        $name,
+                        $propertyName,
+                        $property->oneOf,
+                        $namespace
+                    );
 
                     $parameter->setType($oneOfType);
                 }
             }
+        }
+
+        if ($this->serializableResolver->needsSerialization($class)) {
+            $this->serializableResolver->addSerialization($openApi, $schema, $namespace, $class, $constructor);
         }
 
         return $class;
@@ -120,6 +159,7 @@ readonly class ClassTransformer
     }
 
     private function transformInlineObject(
+        Configuration $configuration,
         OpenApi $openApi,
         string $parentName,
         string $propertyName,
@@ -128,7 +168,7 @@ readonly class ClassTransformer
     ): string {
         $className = $parentName . ucfirst($propertyName);
 
-        $this->transform($openApi, $className, $schema, $namespace);
+        $this->transform($configuration, $openApi, $className, $schema, $namespace);
 
         return $className;
     }
@@ -158,6 +198,7 @@ readonly class ClassTransformer
     }
 
     private function resolveArrayType(
+        Configuration $configuration,
         OpenApi $openApi,
         string $parentName,
         string $propertyName,
@@ -176,7 +217,14 @@ readonly class ClassTransformer
 
         if ($arrayType === Types::Object && $itemsSchema instanceof Schema) {
             $arrayType = $namespace->resolveName(
-                $this->transformInlineObject($openApi, $parentName, $propertyName, $itemsSchema, $namespace)
+                $this->transformInlineObject(
+                    $configuration,
+                    $openApi,
+                    $parentName,
+                    $propertyName,
+                    $itemsSchema,
+                    $namespace
+                )
             );
         }
 
@@ -188,6 +236,7 @@ readonly class ClassTransformer
 
         if ($arrayType === Types::OneOf && $itemsSchema instanceof Schema && is_array($itemsSchema->oneOf)) {
             $oneOfArrayType = $this->transformOneOf(
+                $configuration,
                 $openApi,
                 $parentName,
                 $propertyName,
@@ -222,6 +271,7 @@ readonly class ClassTransformer
      * @param array<Schema|Reference> $oneOf
      */
     private function transformOneOf(
+        Configuration $configuration,
         OpenApi $openApi,
         string $parentName,
         string $propertyName,
@@ -239,6 +289,7 @@ readonly class ClassTransformer
                 $resolvedTypes[] = match ($resolvedType) {
                     Types::Object => $namespace->resolveName(
                         $this->transformInlineObject(
+                            $configuration,
                             $openApi,
                             $parentName,
                             $propertyName . ++$countInlineObjects,

--- a/src/Generator/SerializableResolver.php
+++ b/src/Generator/SerializableResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Generator;
+
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Schema;
+use DateTimeInterface;
+use JsonSerializable;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\Method;
+use Nette\PhpGenerator\Parameter;
+use Nette\PhpGenerator\PhpNamespace;
+use Nette\PhpGenerator\PromotedParameter;
+use Reinfi\OpenApiModels\Exception\InvalidDateFormatException;
+use Reinfi\OpenApiModels\Exception\PropertyNotFoundException;
+
+readonly class SerializableResolver
+{
+    public function __construct(
+        private TypeResolver $typeResolver
+    ) {
+    }
+
+    public function needsSerialization(ClassType $class): bool
+    {
+        foreach ($class->getMethods() as $method) {
+            foreach ($method->getParameters() as $parameter) {
+                if ($parameter->getType() === DateTimeInterface::class) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function addSerialization(
+        OpenApi $openApi,
+        Schema $schema,
+        PhpNamespace $namespace,
+        ClassType $class,
+        Method $constructor
+    ): void {
+        $promotedParameters = array_filter(
+            $constructor->getParameters(),
+            static fn (Parameter $parameter): bool => $parameter instanceof PromotedParameter && $parameter->getType() === DateTimeInterface::class,
+        );
+
+        if (count($promotedParameters) === 0) {
+            return;
+        }
+
+        $namespace->addUse(JsonSerializable::class);
+        $class->setImplements([JsonSerializable::class]);
+
+        $method = $class->addMethod('jsonSerialize')->setReturnType('array');
+
+        $method->addBody('return array_merge(get_object_vars($this), [');
+        foreach ($promotedParameters as $parameter) {
+            $property = $schema->properties[$parameter->getName()] ?? null;
+
+            if (! $property instanceof Schema) {
+                throw new PropertyNotFoundException($parameter->getName());
+            }
+
+            $method->addBody(sprintf(
+                '    \'%1$s\' => $this->%1$s%2$s->format(\'%3$s\'),',
+                $parameter->getName(),
+                $parameter->isNullable() ? '?' : '',
+                $this->resolveFormat($openApi, $property, $parameter)
+            ));
+        }
+        $method->addBody(']);');
+    }
+
+    private function resolveFormat(OpenApi $openApi, Schema $schema, Parameter $parameter): string
+    {
+        $type = $this->typeResolver->resolve($openApi, $schema);
+
+        return match ($type) {
+            Types::Date => 'Y-m-d',
+            Types::DateTime => DateTimeInterface::RFC3339,
+            default => throw new InvalidDateFormatException($parameter->getName())
+        };
+    }
+}

--- a/src/Generator/TypeResolver.php
+++ b/src/Generator/TypeResolver.php
@@ -48,7 +48,11 @@ readonly class TypeResolver
             },
             'integer' => 'int',
             'boolean' => 'bool',
-            'string' => 'string',
+            'string' => match ($schema->format) {
+                'date', => Types::Date,
+                'date-time' => Types::DateTime,
+                default => 'string',
+            },
             'array' => Types::Array,
             'object' => Types::Object,
             default => throw new InvalidArgumentException(sprintf('Not implemented type "%s" found', $schema->type))

--- a/src/Generator/Types.php
+++ b/src/Generator/Types.php
@@ -9,6 +9,8 @@ enum Types: string
     case AnyOf = 'anyOf';
     case OneOf = 'oneOf';
     case Array = 'array';
+    case Date = 'date';
+    case DateTime = 'dateTime';
     case Object = 'object';
     case Enum = 'enum';
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test1.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test1.php
@@ -4,17 +4,29 @@ declare(strict_types=1);
 
 namespace Api\Schema;
 
+use DateTimeInterface;
+
 /**
  * Test1 object to show functionality
  */
-readonly class Test1
+readonly class Test1 implements \JsonSerializable
 {
     public function __construct(
         public int $id,
         public string $email,
         public bool $admin,
         public ?string $changed,
+        public DateTimeInterface $date,
+        public ?DateTimeInterface $dateTime = null,
         public ?bool $deleted = null,
     ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_merge(get_object_vars($this), [
+            'date' => $this->date->format('Y-m-d'),
+            'dateTime' => $this->dateTime?->format('Y-m-d\TH:i:sP'),
+        ]);
     }
 }

--- a/test/Configuration/ConfigurationTest.php
+++ b/test/Configuration/ConfigurationTest.php
@@ -11,16 +11,18 @@ class ConfigurationTest extends TestCase
 {
     public function testItReturnsConfigurationValues(): void
     {
-        $configuration = new Configuration(['path'], 'outputPath', '', false);
+        $configuration = new Configuration(['path'], 'outputPath', '', false, false);
 
         self::assertEquals('outputPath', $configuration->outputPath);
         self::assertEmpty($configuration->namespace);
         self::assertFalse($configuration->clearOutputDirectory);
+        self::assertFalse($configuration->dateTimeAsObject);
         self::assertCount(1, $configuration->paths);
 
-        $configuration = new Configuration(['path'], 'outputPath', 'Api', true);
+        $configuration = new Configuration(['path'], 'outputPath', 'Api', true, true);
 
         self::assertEquals('Api', $configuration->namespace);
         self::assertTrue($configuration->clearOutputDirectory);
+        self::assertTrue($configuration->dateTimeAsObject);
     }
 }

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -25,7 +25,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItGeneratesClassesFromOpenApi(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('Schema');
 
         $openApi = new OpenApi([
@@ -46,6 +46,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->exactly(2))->method('transform')->with(
+            $configuration,
             $openApi,
             $this->callback(static fn (string $name): bool => in_array($name, ['Test1', 'Test2'], true)),
             $this->isInstanceOf(Schema::class),
@@ -65,7 +66,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItGeneratesRequestBodies(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('RequestBody');
 
         $openApi = new OpenApi([
@@ -86,6 +87,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())->method('transform')->with(
+            $configuration,
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),
@@ -105,7 +107,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItGeneratesResponses(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
@@ -126,6 +128,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())->method('transform')->with(
+            $configuration,
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),
@@ -145,7 +148,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItGeneratesReferenceClasses(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
@@ -166,6 +169,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())->method('transform')->with(
+            $configuration,
             $openApi,
             'Test1',
             $this->isInstanceOf(Reference::class),
@@ -185,7 +189,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItGeneratesOnlyJsonSchema(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
@@ -211,6 +215,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())->method('transform')->with(
+            $configuration,
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),
@@ -230,7 +235,7 @@ class ClassGeneratorTest extends TestCase
 
     public function testItSetsCommentIfTopLevelHasDescription(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
         $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
@@ -252,6 +257,7 @@ class ClassGeneratorTest extends TestCase
 
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())->method('transform')->with(
+            $configuration,
             $openApi,
             'Test1',
             $this->isInstanceOf(Schema::class),

--- a/test/Generator/NamespaceResolverTest.php
+++ b/test/Generator/NamespaceResolverTest.php
@@ -49,7 +49,7 @@ class NamespaceResolverTest extends TestCase
 
     public function testItInitializesNamespacesFromConfiguration(): void
     {
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
 
         $resolver = new NamespaceResolver();
 
@@ -72,7 +72,7 @@ class NamespaceResolverTest extends TestCase
         string $configurationNamespace,
         string $expectedNameSpace
     ): void {
-        $configuration = new Configuration([], '', $configurationNamespace, false);
+        $configuration = new Configuration([], '', $configurationNamespace, false, false);
 
         $resolver = new NamespaceResolver();
 

--- a/test/Generator/SerializableResolverTest.php
+++ b/test/Generator/SerializableResolverTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Test\Generator;
+
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Schema;
+use DateTimeInterface;
+use DG\BypassFinals;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+use PHPUnit\Framework\TestCase;
+use Reinfi\OpenApiModels\Exception\InvalidDateFormatException;
+use Reinfi\OpenApiModels\Exception\PropertyNotFoundException;
+use Reinfi\OpenApiModels\Generator\SerializableResolver;
+use Reinfi\OpenApiModels\Generator\TypeResolver;
+use Reinfi\OpenApiModels\Generator\Types;
+
+class SerializableResolverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        BypassFinals::enable();
+    }
+
+    public function testItReturnTrueIfSerializationIsNeeded(): void
+    {
+        $typeResolver = $this->createMock(TypeResolver::class);
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $class->addMethod('__construct')->addPromotedParameter('date')->setType(DateTimeInterface::class);
+
+        $this->assertTrue($resolver->needsSerialization($class));
+    }
+
+    public function testItReturnFalseIfSerializationIsNotNeeded(): void
+    {
+        $typeResolver = $this->createMock(TypeResolver::class);
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $class->addMethod('__construct')->addPromotedParameter('date')->setType('string');
+
+        $this->assertFalse($resolver->needsSerialization($class));
+    }
+
+    public function testItDoesNothingIfNotParameterIsFound(): void
+    {
+        $openApi = new OpenApi([]);
+        $namespace = new PhpNamespace('Api');
+        $schema = new Schema([]);
+
+        $typeResolver = $this->createMock(TypeResolver::class);
+        $typeResolver->expects($this->never())->method('resolve');
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $constructor = $class->addMethod('__construct');
+
+        $resolver->addSerialization($openApi, $schema, $namespace, $class, $constructor);
+
+        self::assertCount(0, $namespace->getUses());
+    }
+
+    public function testItAddsMethodAndBody(): void
+    {
+        $openApi = new OpenApi([]);
+        $namespace = new PhpNamespace('Api');
+
+        $schema = new Schema([
+            'properties' => [
+                'date' => [
+                    'type' => 'string',
+                    'format' => 'date',
+                ],
+                'dateTime' => [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ],
+            ],
+        ]);
+
+        $typeResolver = $this->createMock(TypeResolver::class);
+        $typeResolver->expects($this->exactly(2))->method('resolve')->willReturn(Types::Date, Types::DateTime);
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $constructor = $class->addMethod('__construct');
+        $constructor->addPromotedParameter('date')->setType(DateTimeInterface::class);
+        $constructor->addPromotedParameter('dateTime')->setType(DateTimeInterface::class)->setNullable();
+
+        $resolver->addSerialization($openApi, $schema, $namespace, $class, $constructor);
+
+        self::assertCount(1, $namespace->getUses());
+        self::assertCount(2, $class->getMethods());
+        self::assertCount(1, $class->getImplements());
+
+        $method = $class->getMethod('jsonSerialize');
+
+        self::assertEquals('array', $method->getReturnType());
+        self::assertStringContainsString('\'date\' => $this->date->format(\'Y-m-d\'),', $method->getBody());
+        self::assertStringContainsString(
+            '\'dateTime\' => $this->dateTime?->format(\'Y-m-d\TH:i:sP\'),',
+            $method->getBody()
+        );
+    }
+
+    public function testItThrowsExceptionIfPropertyNotFoundInSchema(): void
+    {
+        self::expectException(PropertyNotFoundException::class);
+        self::expectExceptionMessage('Property "date" was not found in schema');
+
+        $openApi = new OpenApi([]);
+        $namespace = new PhpNamespace('');
+
+        $schema = new Schema([]);
+
+        $typeResolver = $this->createMock(TypeResolver::class);
+        $typeResolver->expects($this->never())->method('resolve');
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $constructor = $class->addMethod('__construct');
+        $constructor->addPromotedParameter('date')->setType(DateTimeInterface::class);
+
+        $resolver->addSerialization($openApi, $schema, $namespace, $class, $constructor);
+    }
+
+    public function testItThrowsExceptionIfPropertyHasInvalidType(): void
+    {
+        self::expectException(InvalidDateFormatException::class);
+        self::expectExceptionMessage('Invalid date format found for property "date"');
+
+        $openApi = new OpenApi([]);
+        $namespace = new PhpNamespace('');
+
+        $schema = new Schema([
+            'properties' => [
+                'date' => [
+                    'type' => 'string',
+                    'format' => 'time',
+                ],
+            ],
+        ]);
+
+        $typeResolver = $this->createMock(TypeResolver::class);
+        $typeResolver->expects($this->once())->method('resolve')->willReturn(Types::Object);
+
+        $resolver = new SerializableResolver($typeResolver);
+
+        $class = new ClassType('Test');
+        $constructor = $class->addMethod('__construct');
+        $constructor->addPromotedParameter('date')->setType(DateTimeInterface::class);
+
+        $resolver->addSerialization($openApi, $schema, $namespace, $class, $constructor);
+    }
+}

--- a/test/Parser/ParserTest.php
+++ b/test/Parser/ParserTest.php
@@ -48,7 +48,7 @@ class ParserTest extends TestCase
         $configuration = new Configuration([
             $this->inputRoot->url() . '/sub',
             $this->inputRoot->url() . '/login.yml',
-        ], '', '', false);
+        ], '', '', false, false);
 
         $parser = new Parser($openApiMerger);
 
@@ -62,7 +62,7 @@ class ParserTest extends TestCase
         $openApiMerger = $this->createMock(OpenApiMerge::class);
         $openApiMerger->expects($this->never())->method('mergeFiles');
 
-        $configuration = new Configuration([], '', '', false);
+        $configuration = new Configuration([], '', '', false, false);
 
         $parser = new Parser($openApiMerger);
 

--- a/test/Writer/ClassWriterTest.php
+++ b/test/Writer/ClassWriterTest.php
@@ -31,7 +31,7 @@ class ClassWriterTest extends TestCase
 
         $writer = new ClassWriter($printer);
 
-        $configuration = new Configuration([], $this->outputDir->url(), '', false);
+        $configuration = new Configuration([], $this->outputDir->url(), '', false, false);
 
         $firstNamespace = new PhpNamespace('Schema');
         $firstNamespace->addClass('ClassFirst');
@@ -60,7 +60,7 @@ class ClassWriterTest extends TestCase
 
         $writer = new ClassWriter($printer);
 
-        $configuration = new Configuration([], $this->outputDir->url(), '', false);
+        $configuration = new Configuration([], $this->outputDir->url(), '', false, false);
 
         $namespace = new PhpNamespace('Schema');
         $namespace->addUse('ClassSecond');

--- a/test/config/acceptance-test.php
+++ b/test/config/acceptance-test.php
@@ -7,4 +7,5 @@ return [
     'outputPath' => __DIR__ . '/../output',
     'namespace' => 'Api',
     'clearOutputDirectory' => false,
+    'dateTimeAsObject' => true,
 ];

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -16,6 +16,7 @@ components:
         - email
         - admin
         - changed
+        - date
       properties:
         id:
           type: number
@@ -26,6 +27,12 @@ components:
         changed:
           type: string
           nullable: true
+        date:
+          type: string
+          format: date
+        dateTime:
+          type: string
+          format: date-time
         deleted:
           type: boolean
 


### PR DESCRIPTION
Adds support for date and date-time format.

```yml
components:
  schemas:
    Test1:
      type: object
      required:
        - date
      properties:
        date:
          type: string
          format: date
        dateTime:
          type: string
          format: date-time
```

Depending on the configuration flag it generates `string` or `DateTimeInterface`. If it is the DateTime interface the class will implement `JsonSerializable` and provide correct open api values.