### PR TITLE
Support datetime array

### DIFF
--- a/src/Exception/UnsupportedTypeForArrayException.php
+++ b/src/Exception/UnsupportedTypeForArrayException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class UnsupportedTypeForArrayException extends Exception
+{
+    public function __construct(string $type)
+    {
+        parent::__construct(
+            sprintf('Type "%s" is currently not supported for array definition', $type)
+        );
+    }
+}

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -13,6 +13,7 @@ use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\PromotedParameter;
 use Reinfi\OpenApiModels\Configuration\Configuration;
 use Reinfi\OpenApiModels\Exception\UnresolvedArrayTypeException;
+use Reinfi\OpenApiModels\Exception\UnsupportedTypeForArrayException;
 use Reinfi\OpenApiModels\Exception\UnsupportedTypeForOneOfException;
 
 readonly class ClassTransformer
@@ -243,6 +244,11 @@ readonly class ClassTransformer
                 $itemsSchema->oneOf,
                 $namespace
             );
+
+            if (str_contains($oneOfArrayType, DateTimeInterface::class)) {
+                throw new UnsupportedTypeForArrayException('date or datetime in oneOf');
+            }
+
             $parameter->setType('array')->addComment(
                 sprintf('@var array<%s>%s $%s', $oneOfArrayType, $nullablePart, $parameter->getName())
             );

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -249,6 +249,14 @@ readonly class ClassTransformer
             return;
         }
 
+        if (in_array($arrayType, [Types::Date, Types::DateTime], true)) {
+            $parameter->setType('array')->addComment(
+                sprintf('@var array<%s>%s $%s', DateTimeInterface::class, $nullablePart, $parameter->getName())
+            );
+            $namespace->addUse(DateTimeInterface::class);
+            return;
+        }
+
         if ($arrayType instanceof Types) {
             throw new UnresolvedArrayTypeException($arrayType->value);
         }

--- a/src/Generator/SerializableResolver.php
+++ b/src/Generator/SerializableResolver.php
@@ -76,12 +76,12 @@ readonly class SerializableResolver
                     );
                     if ($parameter->isNullable()) {
                         $method->addBody(sprintf(
-                            '    \'%1$s\' => $this->%1$s === null ? $this->%1$s : %2$s',
+                            '    \'%1$s\' => $this->%1$s === null ? $this->%1$s : %2$s,',
                             $parameter->getName(),
                             $arrayMapFunction
                         ));
                     } else {
-                        $method->addBody(sprintf('    \'%1$s\' => %2$s', $parameter->getName(), $arrayMapFunction));
+                        $method->addBody(sprintf('    \'%1$s\' => %2$s,', $parameter->getName(), $arrayMapFunction));
                     }
                     break;
                 case Types::OneOf :

--- a/src/Generator/SerializableResolver.php
+++ b/src/Generator/SerializableResolver.php
@@ -12,7 +12,6 @@ use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\Parameter;
 use Nette\PhpGenerator\PhpNamespace;
-use Nette\PhpGenerator\PromotedParameter;
 use Reinfi\OpenApiModels\Exception\InvalidDateFormatException;
 use Reinfi\OpenApiModels\Exception\PropertyNotFoundException;
 
@@ -27,8 +26,7 @@ readonly class SerializableResolver
     {
         foreach ($class->getMethods() as $method) {
             foreach ($method->getParameters() as $parameter) {
-                $type = $parameter->getType(true);
-                if ($type?->allows(DateTimeInterface::class)) {
+                if ($this->needsParameterSerialization($parameter)) {
                     return true;
                 }
             }
@@ -46,9 +44,7 @@ readonly class SerializableResolver
     ): void {
         $promotedParameters = array_filter(
             $constructor->getParameters(),
-            static fn (Parameter $parameter): bool => $parameter instanceof PromotedParameter && $parameter->getType(
-                true
-            )?->allows(DateTimeInterface::class),
+            fn (Parameter $parameter): bool => $this->needsParameterSerialization($parameter),
         );
 
         if (count($promotedParameters) === 0) {
@@ -71,6 +67,23 @@ readonly class SerializableResolver
             $type = $this->typeResolver->resolve($openApi, $property);
 
             switch ($type) {
+                case Types::Array :
+                    $arrayMapFunction = sprintf(
+                        'array_map(static fn (%2$s $date): string => $date->format(\'%3$s\'), $this->%1$s)',
+                        $parameter->getName(),
+                        DateTimeInterface::class,
+                        $this->resolveFormat($openApi, $property, $type, $parameter)
+                    );
+                    if ($parameter->isNullable()) {
+                        $method->addBody(sprintf(
+                            '    \'%1$s\' => $this->%1$s === null ? $this->%1$s : %2$s',
+                            $parameter->getName(),
+                            $arrayMapFunction
+                        ));
+                    } else {
+                        $method->addBody(sprintf('    \'%1$s\' => %2$s', $parameter->getName(), $arrayMapFunction));
+                    }
+                    break;
                 case Types::OneOf :
                     $method->addBody(sprintf(
                         '    \'%1$s\' => $this->%1$s instanceOf %2$s ? $this->%1$s->format(\'%3$s\') : $this->%1$s,',
@@ -91,6 +104,22 @@ readonly class SerializableResolver
         $method->addBody(']);');
     }
 
+    private function needsParameterSerialization(Parameter $parameter): bool
+    {
+        $type = $parameter->getType(true);
+        if ($type?->allows(DateTimeInterface::class)) {
+            return true;
+        }
+
+        if ($type?->getSingleName() === 'array' && $parameter->getComment() !== null) {
+            if (str_contains($parameter->getComment(), DateTimeInterface::class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function resolveFormat(OpenApi $openApi, Schema $schema, Types|string $type, Parameter $parameter): string
     {
         if ($type === Types::OneOf) {
@@ -100,6 +129,10 @@ readonly class SerializableResolver
                     break;
                 }
             }
+        }
+
+        if ($type === Types::Array && $schema->items !== null) {
+            $type = $this->typeResolver->resolve($openApi, $schema->items);
         }
 
         return match ($type) {

--- a/test/Acceptance/ExpectedClasses/Schema/Test6.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test6.php
@@ -22,7 +22,7 @@ readonly class Test6 implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return array_merge(get_object_vars($this), [
-            'dates' => $this->dates === null ? $this->dates : array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $this->dates)
+            'dates' => $this->dates === null ? $this->dates : array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $this->dates),
         ]);
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test6.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test6.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Api\Schema;
 
-readonly class Test6
+use DateTimeInterface;
+
+readonly class Test6 implements \JsonSerializable
 {
     public function __construct(
         public string $id,
@@ -12,6 +14,15 @@ readonly class Test6
         public ?array $tests = null,
         /** @var Test6States[] $states */
         public array $states,
+        /** @var array<DateTimeInterface>|null $dates */
+        public ?array $dates = null,
     ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_merge(get_object_vars($this), [
+            'dates' => $this->dates === null ? $this->dates : array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $this->dates)
+        ]);
     }
 }

--- a/test/Generator/ClassTransformerTest.php
+++ b/test/Generator/ClassTransformerTest.php
@@ -17,6 +17,7 @@ use Nette\PhpGenerator\PromotedParameter;
 use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Configuration\Configuration;
 use Reinfi\OpenApiModels\Exception\UnresolvedArrayTypeException;
+use Reinfi\OpenApiModels\Exception\UnsupportedTypeForArrayException;
 use Reinfi\OpenApiModels\Exception\UnsupportedTypeForOneOfException;
 use Reinfi\OpenApiModels\Generator\ClassReference;
 use Reinfi\OpenApiModels\Generator\ClassTransformer;
@@ -1075,6 +1076,70 @@ class ClassTransformerTest extends TestCase
         self::assertCount(1, $classes);
         self::assertEquals('array', $parameter->getType());
         self::assertEquals('@var array<Test1|Test2>|null $values', $parameter->getComment());
+    }
+
+    public function testItThrowsExceptionIfOneOfContainerDate(): void
+    {
+        self::expectException(UnsupportedTypeForArrayException::class);
+        self::expectExceptionMessage(
+            'Type "date or datetime in oneOf" is currently not supported for array definition'
+        );
+
+        $openApi = new OpenApi([]);
+        $namespace = new PhpNamespace('');
+        $parameter = new PromotedParameter('values');
+        $configuration = new Configuration([], '', '', false, true);
+
+        $propertyResolver = $this->createMock(PropertyResolver::class);
+        $typeResolver = $this->createMock(TypeResolver::class);
+        $referenceResolver = $this->createMock(ReferenceResolver::class);
+        $serializableResolver = $this->createMock(SerializableResolver::class);
+
+        $referenceResolver->expects($this->never())->method('resolve');
+        $typeResolver->expects($this->exactly(4))->method('resolve')->with(
+            $openApi,
+            $this->callback(function (Schema|Reference $schema): bool {
+                if ($schema instanceof Reference) {
+                    return $schema->getReference() === '#/components/schemas/Test1';
+                }
+
+                if (is_array($schema->oneOf)) {
+                    return true;
+                }
+
+                return $schema->type === 'array' || ($schema->type === 'string' && $schema->format === 'date');
+            }),
+        )->willReturn(Types::Array, Types::OneOf, new ClassReference(OpenApiType::Schemas, 'Test1'), Types::Date);
+
+        $propertyResolver->expects($this->once())->method('resolve')->willReturn($parameter);
+
+        $transformer = new ClassTransformer(
+            $propertyResolver,
+            $typeResolver,
+            $referenceResolver,
+            $serializableResolver
+        );
+
+        $schema = new Schema([
+            'properties' => [
+                'values' => [
+                    'type' => 'array',
+                    'items' => [
+                        'oneOf' => [
+                            [
+                                '$ref' => '#/components/schemas/Test1',
+                            ],
+                            [
+                                'type' => 'string',
+                                'format' => 'date',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $transformer->transform($configuration, $openApi, 'Test', $schema, $namespace);
     }
 
     public function testItResolvesOneOf(): void

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -116,6 +116,11 @@ components:
             enum:
               - positive
               - negative
+        dates:
+          type: array
+          items:
+            type: string
+            format: date
 
   requestBodies:
     RequestBody1:


### PR DESCRIPTION
Supports date time as type in arrays. OneOf with dateTime in arrays is not supported at the moment. May be implemented in the future. 