### PR TITLE
only support json content type

### DIFF
--- a/src/Exception/OnlyJsonContentTypeSupported.php
+++ b/src/Exception/OnlyJsonContentTypeSupported.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class OnlyJsonContentTypeSupported extends Exception
+{
+    /**
+     * @param string[] $foundMediaTypes
+     */
+    public function __construct(array $foundMediaTypes)
+    {
+        parent::__construct(sprintf(
+            'Only "application/json" is supported as media type, found: %s',
+            join(',', $foundMediaTypes)
+        ));
+    }
+}


### PR DESCRIPTION
Reason:

There is only a json serialize function and other formats may require different serialization. 

And for future work on this it would be much simpler if there is only one support content-type. 
I may change this decision in the future, but for now it suites best for me. 