### PR TITLE
do not fail if required is set to true

### DIFF
--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -75,7 +75,8 @@ readonly class ClassTransformer
                 $schemasForClass,
                 static fn (array $requiredProperties, Schema $schema) => array_merge(
                     $requiredProperties,
-                    $schema->required ?? []
+                    // @phpstan-ignore-next-line Invalid definition in class.
+                    is_array($schema->required) ? $schema->required : []
                 ),
                 []
             );


### PR DESCRIPTION
This is possible in OpenApi because required in Parameters is allowed to be boolean. But for objects this has no meaning and should be ignored. 