### PR TITLE
fix to accept multitype param for nullable 

### DIFF
--- a/src/Generator/TypeResolver.php
+++ b/src/Generator/TypeResolver.php
@@ -64,7 +64,12 @@ readonly class TypeResolver
             return Types::Enum;
         }
 
-        $type = match ($schema->type) {
+        $schemaType = $schema->type;
+        if (is_array($schema->type) && count($schema->type) == 2 && in_array("null", $schema->type)) {
+            $schemaType = current( array_filter($schema->type, fn ($x) => $x !== 'null'));
+        }
+
+        $type = match ($schemaType) {
             'number' => match ($schema->format) {
                 'double', 'float' => 'float',
                 default => 'int'


### PR DESCRIPTION
To Accept  openapi type like

```
- string
- null
```

becouse API DOG generate like this if i allow null to params.

logic is like

if type is array and just have a 2 choice and 1 is "null" that means the type is the onather  nullable.

so I changed