### PR TITLE
Handle numeric enum names (by converting them to english words)

### DIFF
--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -380,6 +380,11 @@ readonly class ClassTransformer
             }
 
             if (! Helpers::isIdentifier($enumCaseName)) {
+                if (is_numeric($enumCaseName)) {
+                  $formatter = new \NumberFormatter('en', \NumberFormatter::SPELLOUT);
+                  $enumCaseName = $formatter->format(intval($enumCaseName));
+                }
+
                 $enumCaseNameParts = preg_split('/[^A-z0-9]+/', $enumCaseName);
                 if (! is_array($enumCaseNameParts)) {
                     throw new InvalidArgumentException(


### PR DESCRIPTION
I ran into one problem when I tried generating models for an OpenAPI definition:

The OpenAPI definition had tons and tons of enums with numeric strings as their values.

Since a number is not an acceptable identifier in PHP it rightfully failed on those.

Taking some inspiration from [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) I decided to give it a go and convert the numbers to English words to make them viable identifiers.