### PR TITLE
Improved type hinting to pass some PHPStan / PHPCS rules better

### DIFF
--- a/src/Generator/ArrayObjectResolver.php
+++ b/src/Generator/ArrayObjectResolver.php
@@ -68,8 +68,8 @@ class ArrayObjectResolver
             );
         }
 
-        $class->addComment(sprintf('@implements %s<int, %s>', ArrayAccess::class, $type));
-        $class->addComment(sprintf('@implements %s<%s>', IteratorAggregate::class, $type));
+        $class->addComment(sprintf('@implements \%s<int, %s>', ArrayAccess::class, $type));
+        $class->addComment(sprintf('@implements \%s<%s>', IteratorAggregate::class, $type));
 
         return $this;
     }

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -356,7 +356,7 @@ readonly class ClassTransformer
         }
 
         foreach ($schema->enum as $index => $enumValue) {
-            if ($enumValue === NULL) {
+            if ($enumValue === null) {
                 continue;
             }
 

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -356,6 +356,10 @@ readonly class ClassTransformer
         }
 
         foreach ($schema->enum as $index => $enumValue) {
+            if ($enumValue === NULL) {
+                continue;
+            }
+
             if (! is_string($enumValue) && ! is_int($enumValue)) {
                 throw new InvalidArgumentException(sprintf(
                     'Enum value must be string or integer, got %s',

--- a/src/Serialization/ArrayObjectSerialization.php
+++ b/src/Serialization/ArrayObjectSerialization.php
@@ -74,7 +74,9 @@ class ArrayObjectSerialization
         bool $isDateTime
     ): void {
         $parameter = $constructor->getParameter('items');
+
         $method = $class->addMethod('jsonSerialize')
+            ->addComment(sprintf('@return %1$s[]', $parameter->getType()))
             ->setReturnType('array')
             ->setReturnNullable($parameter->isNullable());
 

--- a/src/Serialization/ArrayObjectSerialization.php
+++ b/src/Serialization/ArrayObjectSerialization.php
@@ -76,7 +76,7 @@ class ArrayObjectSerialization
         $parameter = $constructor->getParameter('items');
 
         $method = $class->addMethod('jsonSerialize')
-            ->addComment(sprintf('@return %1$s[]', $parameter->getType()))
+            ->addComment(sprintf('@return array<%1$s>', $parameter->getType()))
             ->setReturnType('array')
             ->setReturnNullable($parameter->isNullable());
 

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -113,13 +113,13 @@ readonly class SerializableResolver
             return;
         }
 
-        $method->addBody(
-            $this->intend(
-                'static fn (mixed $value, string $key): bool => !(in_array($key, [...?], true) && $value === null),'
-            ),
-            [$notRequiredParameterNames]
-        )->addBody($this->intend('ARRAY_FILTER_USE_BOTH'))
-            ->addBody(');');
+        $method->addBody($this->intend('static fn (mixed $value, string $key): bool => !(in_array($key, ['));
+
+        array_map(fn (string $name) => $method->addBody($this->intend(sprintf('\'%1$s\',', $name), 2)), $notRequiredParameterNames);
+
+        $method->addBody($this->intend('], true) && $value === null),'));
+        $method->addBody($this->intend('ARRAY_FILTER_USE_BOTH'));
+        $method->addBody(');');
     }
 
     private function intend(string $code, int $intends = 1): string

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -108,7 +108,7 @@ readonly class SerializableResolver
         $method->addBody($this->intend('],'));
 
         if (count($notRequiredParameterNames) === 1) {
-            $method->addBody($this->intend('static fn (mixed $value): bool => $value === null'));
+            $method->addBody($this->intend('static fn (mixed $value): bool => $value !== null'));
             $method->addBody(');');
             return;
         }

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -107,6 +107,12 @@ readonly class SerializableResolver
 
         $method->addBody($this->intend('],'));
 
+        if (count($notRequiredParameterNames) === 1) {
+            $method->addBody($this->intend('static fn (mixed $value): bool => $value === null'));
+            $method->addBody(');');
+            return;
+        }
+
         $method->addBody(
             $this->intend(
                 'static fn (mixed $value, string $key): bool => !(in_array($key, [...?], true) && $value === null),'

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -109,7 +109,7 @@ readonly class SerializableResolver
 
         if (count($notRequiredParameterNames) === count($parameters)) {
             $method->addBody($this->intend('static fn (mixed $value): bool => $value !== null'));
-        } else if (count($notRequiredParameterNames) === 1) {
+        } elseif (count($notRequiredParameterNames) === 1) {
             $method->addBody($this->intend(
                 sprintf(
                     'static fn (mixed $value, string $key): bool => !($key === \'%1$s\' && $value === null),',

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -115,7 +115,10 @@ readonly class SerializableResolver
 
         $method->addBody($this->intend('static fn (mixed $value, string $key): bool => !(in_array($key, ['));
 
-        array_map(fn (string $name) => $method->addBody($this->intend(sprintf('\'%1$s\',', $name), 2)), $notRequiredParameterNames);
+        array_map(
+            fn (string $name) => $method->addBody($this->intend(sprintf('\'%1$s\',', $name), 2)),
+            $notRequiredParameterNames
+        );
 
         $method->addBody($this->intend('], true) && $value === null),'));
         $method->addBody($this->intend('ARRAY_FILTER_USE_BOTH'));

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -107,21 +107,28 @@ readonly class SerializableResolver
 
         $method->addBody($this->intend('],'));
 
-        if (count($notRequiredParameterNames) === 1) {
+        if (count($notRequiredParameterNames) === count($parameters)) {
             $method->addBody($this->intend('static fn (mixed $value): bool => $value !== null'));
-            $method->addBody(');');
-            return;
+        } else if (count($notRequiredParameterNames) === 1) {
+            $method->addBody($this->intend(
+                sprintf(
+                    'static fn (mixed $value, string $key): bool => !($key === \'%1$s\' && $value === null),',
+                    reset($notRequiredParameterNames)
+                )
+            ));
+            $method->addBody($this->intend('ARRAY_FILTER_USE_BOTH'));
+        } else {
+            $method->addBody($this->intend('static fn (mixed $value, string $key): bool => !(in_array($key, ['));
+
+            array_map(
+                fn (string $name) => $method->addBody($this->intend(sprintf('\'%1$s\',', $name), 2)),
+                $notRequiredParameterNames
+            );
+
+            $method->addBody($this->intend('], true) && $value === null),'));
+            $method->addBody($this->intend('ARRAY_FILTER_USE_BOTH'));
         }
 
-        $method->addBody($this->intend('static fn (mixed $value, string $key): bool => !(in_array($key, ['));
-
-        array_map(
-            fn (string $name) => $method->addBody($this->intend(sprintf('\'%1$s\',', $name), 2)),
-            $notRequiredParameterNames
-        );
-
-        $method->addBody($this->intend('], true) && $value === null),'));
-        $method->addBody($this->intend('ARRAY_FILTER_USE_BOTH'));
         $method->addBody(');');
     }
 

--- a/src/Serialization/SerializableResolver.php
+++ b/src/Serialization/SerializableResolver.php
@@ -62,6 +62,7 @@ readonly class SerializableResolver
         $class->setImplements([...$class->getImplements(), JsonSerializable::class]);
 
         $method = $class->addMethod('jsonSerialize')
+            ->addComment('@return array<string, mixed>')
             ->setReturnType('array');
 
         /** @var string[] $parameterSerializeCodeParts */

--- a/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
+++ b/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
@@ -25,7 +25,7 @@ readonly class RequestBody1 implements JsonSerializable
                 'id' => $this->id,
                 'test' => $this->test,
             ],
-            static fn (mixed $value): bool => $value === null
+            static fn (mixed $value): bool => $value !== null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
+++ b/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
@@ -15,6 +15,9 @@ readonly class RequestBody1 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -22,8 +25,7 @@ readonly class RequestBody1 implements JsonSerializable
                 'id' => $this->id,
                 'test' => $this->test,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['test'], true) && $value === null),
-            ARRAY_FILTER_USE_BOTH
+            static fn (mixed $value): bool => $value === null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
+++ b/test/Acceptance/ExpectedClasses/RequestBody/RequestBody1.php
@@ -25,7 +25,8 @@ readonly class RequestBody1 implements JsonSerializable
                 'id' => $this->id,
                 'test' => $this->test,
             ],
-            static fn (mixed $value): bool => $value !== null
+            static fn (mixed $value, string $key): bool => !($key === 'test' && $value === null),
+            ARRAY_FILTER_USE_BOTH
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Response/Response1.php
+++ b/test/Acceptance/ExpectedClasses/Response/Response1.php
@@ -25,6 +25,9 @@ readonly class Response1 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -34,7 +37,11 @@ readonly class Response1 implements JsonSerializable
                 'items' => $this->items,
                 'whoKnows' => $this->whoKnows,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['test', 'items', 'whoKnows'], true) && $value === null),
+            static fn (mixed $value, string $key): bool => !(in_array($key, [
+                'test',
+                'items',
+                'whoKnows',
+            ], true) && $value === null),
             ARRAY_FILTER_USE_BOTH
         );
     }

--- a/test/Acceptance/ExpectedClasses/Schema/Test1.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test1.php
@@ -23,6 +23,9 @@ readonly class Test1 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -35,7 +38,10 @@ readonly class Test1 implements JsonSerializable
                 'dateTime' => $this->dateTime?->format('Y-m-d\TH:i:sP'),
                 'deleted' => $this->deleted,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['dateTime', 'deleted'], true) && $value === null),
+            static fn (mixed $value, string $key): bool => !(in_array($key, [
+                'dateTime',
+                'deleted',
+            ], true) && $value === null),
             ARRAY_FILTER_USE_BOTH
         );
     }

--- a/test/Acceptance/ExpectedClasses/Schema/Test10.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test10.php
@@ -17,6 +17,9 @@ readonly class Test10 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test10AllOfThem.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test10AllOfThem.php
@@ -15,6 +15,9 @@ readonly class Test10AllOfThem implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test11.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test11.php
@@ -18,6 +18,9 @@ readonly class Test11 implements JsonSerializable
         $this->dictionaries = $dictionaries;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test12.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test12.php
@@ -16,6 +16,9 @@ readonly class Test12 implements JsonSerializable
         $this->dictionaries = $dictionaries;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test13.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test13.php
@@ -16,6 +16,9 @@ readonly class Test13 implements JsonSerializable
         $this->dictionaries = $dictionaries;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test14.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test14.php
@@ -16,6 +16,9 @@ readonly class Test14 implements JsonSerializable
         $this->dictionaries = $dictionaries;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test14DictionaryValue.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test14DictionaryValue.php
@@ -15,6 +15,9 @@ readonly class Test14DictionaryValue implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test15.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test15.php
@@ -16,6 +16,9 @@ readonly class Test15 implements JsonSerializable
         $this->dictionaries = $dictionaries;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
@@ -26,7 +26,8 @@ readonly class Test16OneOfArray implements JsonSerializable
                 'requiredValue' => $this->requiredValue,
                 'noneRequiredValue' => $this->noneRequiredValue,
             ],
-            static fn (mixed $value): bool => $value !== null
+            static fn (mixed $value, string $key): bool => !($key === 'noneRequiredValue' && $value === null),
+            ARRAY_FILTER_USE_BOTH
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
@@ -16,6 +16,9 @@ readonly class Test16OneOfArray implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -23,8 +26,7 @@ readonly class Test16OneOfArray implements JsonSerializable
                 'requiredValue' => $this->requiredValue,
                 'noneRequiredValue' => $this->noneRequiredValue,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['noneRequiredValue'], true) && $value === null),
-            ARRAY_FILTER_USE_BOTH
+            static fn (mixed $value): bool => $value === null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test16OneOfArray.php
@@ -26,7 +26,7 @@ readonly class Test16OneOfArray implements JsonSerializable
                 'requiredValue' => $this->requiredValue,
                 'noneRequiredValue' => $this->noneRequiredValue,
             ],
-            static fn (mixed $value): bool => $value === null
+            static fn (mixed $value): bool => $value !== null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test17SingleOptional.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test17SingleOptional.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+use JsonSerializable;
+
+readonly class Test17SingleOptional implements JsonSerializable
+{
+    public function __construct(
+        public ?int $id = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_filter(
+            [
+                'id' => $this->id,
+            ],
+            static fn (mixed $value): bool => $value !== null
+        );
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/Test18MultipleOptional.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test18MultipleOptional.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+use DateTimeInterface;
+use JsonSerializable;
+
+readonly class Test18MultipleOptional implements JsonSerializable
+{
+    public function __construct(
+        public ?int $id = null,
+        public ?string $email = null,
+        public ?bool $admin = null,
+        public ?string $changed = null,
+        public ?DateTimeInterface $date = null,
+        public ?DateTimeInterface $dateTime = null,
+        public ?bool $deleted = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_filter(
+            [
+                'id' => $this->id,
+                'email' => $this->email,
+                'admin' => $this->admin,
+                'changed' => $this->changed,
+                'date' => $this->date?->format('Y-m-d'),
+                'dateTime' => $this->dateTime?->format('Y-m-d\TH:i:sP'),
+                'deleted' => $this->deleted,
+            ],
+            static fn (mixed $value): bool => $value !== null
+        );
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/Test19MultipleRequiredSingleOptional.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test19MultipleRequiredSingleOptional.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+use JsonSerializable;
+
+readonly class Test19MultipleRequiredSingleOptional implements JsonSerializable
+{
+    public function __construct(
+        public int $id,
+        public ?string $changed,
+        public ?string $email = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_filter(
+            [
+                'id' => $this->id,
+                'changed' => $this->changed,
+                'email' => $this->email,
+            ],
+            static fn (mixed $value, string $key): bool => !($key === 'email' && $value === null),
+            ARRAY_FILTER_USE_BOTH
+        );
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/Test2.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test2.php
@@ -17,6 +17,9 @@ readonly class Test2 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test20MultipleRequiredMultipleOptional.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test20MultipleRequiredMultipleOptional.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+use JsonSerializable;
+
+readonly class Test20MultipleRequiredMultipleOptional implements JsonSerializable
+{
+    public function __construct(
+        public int $id,
+        public ?string $changed,
+        public ?string $email = null,
+        public ?bool $admin = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_filter(
+            [
+                'id' => $this->id,
+                'changed' => $this->changed,
+                'email' => $this->email,
+                'admin' => $this->admin,
+            ],
+            static fn (mixed $value, string $key): bool => !(in_array($key, [
+                'email',
+                'admin',
+            ], true) && $value === null),
+            ARRAY_FILTER_USE_BOTH
+        );
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/Test3.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test3.php
@@ -31,7 +31,7 @@ readonly class Test3 implements JsonSerializable
                 'inline' => $this->inline,
                 'name' => $this->name,
             ],
-            static fn (mixed $value): bool => $value === null
+            static fn (mixed $value): bool => $value !== null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test3.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test3.php
@@ -18,6 +18,9 @@ readonly class Test3 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -28,8 +31,7 @@ readonly class Test3 implements JsonSerializable
                 'inline' => $this->inline,
                 'name' => $this->name,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['name'], true) && $value === null),
-            ARRAY_FILTER_USE_BOTH
+            static fn (mixed $value): bool => $value === null
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test3.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test3.php
@@ -31,7 +31,8 @@ readonly class Test3 implements JsonSerializable
                 'inline' => $this->inline,
                 'name' => $this->name,
             ],
-            static fn (mixed $value): bool => $value !== null
+            static fn (mixed $value, string $key): bool => !($key === 'name' && $value === null),
+            ARRAY_FILTER_USE_BOTH
         );
     }
 }

--- a/test/Acceptance/ExpectedClasses/Schema/Test4.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test4.php
@@ -19,6 +19,9 @@ readonly class Test4 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -30,7 +33,10 @@ readonly class Test4 implements JsonSerializable
                 'oneOfEnum' => $this->oneOfEnum,
                 'oneOfDate' => $this->oneOfDate instanceOf DateTimeInterface ? $this->oneOfDate->format('Y-m-d') : $this->oneOfDate,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['oneOfEnum', 'oneOfDate'], true) && $value === null),
+            static fn (mixed $value, string $key): bool => !(in_array($key, [
+                'oneOfEnum',
+                'oneOfDate',
+            ], true) && $value === null),
             ARRAY_FILTER_USE_BOTH
         );
     }

--- a/test/Acceptance/ExpectedClasses/Schema/Test5.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test5.php
@@ -19,6 +19,9 @@ readonly class Test5 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/test/Acceptance/ExpectedClasses/Schema/Test6.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test6.php
@@ -22,6 +22,9 @@ readonly class Test6 implements JsonSerializable
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return array_filter(
@@ -32,7 +35,11 @@ readonly class Test6 implements JsonSerializable
                 'dates' => $this->dates === null ? $this->dates : array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $this->dates),
                 'arrayOfArray' => $this->arrayOfArray,
             ],
-            static fn (mixed $value, string $key): bool => !(in_array($key, ['tests', 'dates', 'arrayOfArray'], true) && $value === null),
+            static fn (mixed $value, string $key): bool => !(in_array($key, [
+                'tests',
+                'dates',
+                'arrayOfArray',
+            ], true) && $value === null),
             ARRAY_FILTER_USE_BOTH
         );
     }

--- a/test/Acceptance/ExpectedClasses/Schema/Test7.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test7.php
@@ -13,8 +13,8 @@ use JsonSerializable;
 use Traversable;
 
 /**
- * @implements ArrayAccess<int, Test1>
- * @implements IteratorAggregate<Test1>
+ * @implements \ArrayAccess<int, Test1>
+ * @implements \IteratorAggregate<Test1>
  */
 readonly class Test7 implements IteratorAggregate, Countable, ArrayAccess, JsonSerializable
 {
@@ -56,6 +56,9 @@ readonly class Test7 implements IteratorAggregate, Countable, ArrayAccess, JsonS
         throw new BadMethodCallException('Object is readOnly');
     }
 
+    /**
+     * @return array<Test1>
+     */
     public function jsonSerialize(): array
     {
         return $this->items;

--- a/test/Acceptance/ExpectedClasses/Schema/Test8.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test8.php
@@ -14,8 +14,8 @@ use JsonSerializable;
 use Traversable;
 
 /**
- * @implements ArrayAccess<int, DateTimeInterface>
- * @implements IteratorAggregate<DateTimeInterface>
+ * @implements \ArrayAccess<int, DateTimeInterface>
+ * @implements \IteratorAggregate<DateTimeInterface>
  */
 readonly class Test8 implements IteratorAggregate, Countable, ArrayAccess, JsonSerializable
 {
@@ -55,6 +55,9 @@ readonly class Test8 implements IteratorAggregate, Countable, ArrayAccess, JsonS
         throw new BadMethodCallException('Object is readOnly');
     }
 
+    /**
+     * @return array<array>
+     */
     public function jsonSerialize(): ?array
     {
         return $this->items === null ? $this->items : array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $this->items);

--- a/test/Acceptance/ExpectedClasses/Schema/Test9.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test9.php
@@ -13,8 +13,8 @@ use JsonSerializable;
 use Traversable;
 
 /**
- * @implements ArrayAccess<int, Test1|Test2|int[]>
- * @implements IteratorAggregate<Test1|Test2|int[]>
+ * @implements \ArrayAccess<int, Test1|Test2|int[]>
+ * @implements \IteratorAggregate<Test1|Test2|int[]>
  */
 readonly class Test9 implements IteratorAggregate, Countable, ArrayAccess, JsonSerializable
 {
@@ -62,6 +62,9 @@ readonly class Test9 implements IteratorAggregate, Countable, ArrayAccess, JsonS
         throw new BadMethodCallException('Object is readOnly');
     }
 
+    /**
+     * @return array<Test1|Test2|array>
+     */
     public function jsonSerialize(): array
     {
         return $this->items;

--- a/test/Generator/ArrayObjectResolverTest.php
+++ b/test/Generator/ArrayObjectResolverTest.php
@@ -46,32 +46,32 @@ class ArrayObjectResolverTest extends TestCase
         yield [
             'arrayType' => 'string',
             'expectedDocComments' => [
-                '@implements ArrayAccess<int, string>',
-                '@implements IteratorAggregate<string>',
+                '@implements \ArrayAccess<int, string>',
+                '@implements \IteratorAggregate<string>',
             ],
         ];
 
         yield [
             'arrayType' => 'Api\Schema\Test1',
             'expectedDocComments' => [
-                '@implements ArrayAccess<int, Test1>',
-                '@implements IteratorAggregate<Test1>',
+                '@implements \ArrayAccess<int, Test1>',
+                '@implements \IteratorAggregate<Test1>',
             ],
         ];
 
         yield [
             'arrayType' => 'DateTimeInterface',
             'expectedDocComments' => [
-                '@implements ArrayAccess<int, DateTimeInterface>',
-                '@implements IteratorAggregate<DateTimeInterface>',
+                '@implements \ArrayAccess<int, DateTimeInterface>',
+                '@implements \IteratorAggregate<DateTimeInterface>',
             ],
         ];
 
         yield [
             'arrayType' => 'Api\Schema\Test1|Api\Schema\Test2',
             'expectedDocComments' => [
-                '@implements ArrayAccess<int, Test1|Test2>',
-                '@implements IteratorAggregate<Test1|Test2>',
+                '@implements \ArrayAccess<int, Test1|Test2>',
+                '@implements \IteratorAggregate<Test1|Test2>',
             ],
         ];
     }

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -340,6 +340,63 @@ components:
               items:
                 type: integer
 
+    Test17SingleOptional:
+      type: object
+      properties:
+        id:
+          type: number
+
+    Test18MultipleOptional:
+      type: object
+      properties:
+        id:
+          type: number
+        email:
+          type: string
+        admin:
+          type: boolean
+        changed:
+          type: string
+          nullable: true
+        date:
+          type: string
+          format: date
+        dateTime:
+          type: string
+          format: date-time
+        deleted:
+          type: boolean
+
+    Test19MultipleRequiredSingleOptional:
+      type: object
+      required:
+        - id
+        - changed
+      properties:
+        id:
+          type: number
+        email:
+          type: string
+        changed:
+          type: string
+          nullable: true
+
+    Test20MultipleRequiredMultipleOptional:
+      type: object
+      required:
+        - id
+        - changed
+      properties:
+        id:
+          type: number
+        email:
+          type: string
+        admin:
+          type: boolean
+        changed:
+          type: string
+          nullable: true
+
   requestBodies:
     RequestBody1:
       content:


### PR DESCRIPTION
I generally believe that auto-generated code should not be made to pass the coding style of the project that uses it – but this code was so close that I decided to give it a quick look to see if my PHPStan and PHPCS configs required required some adaptions to pass or if all could be auto-fixed.

This PR is a summary of all the PHPStan / PHPCS fixed I found and which would be feasible to do directly in this project, and which should not have any negative side consequences.

I have kept the commits atomic and descriptive.

---

## Copilot summary

This pull request includes a variety of changes to improve code clarity, ensure proper type annotations, and enhance the handling of nullable and non-required parameters in JSON serialization. The changes span across multiple files, focusing on both the main codebase and test files.

### Improvements to type annotations and interface clarity:
* Updated `@implements` annotations in `src/Generator/ArrayObjectResolver.php` to include fully qualified class names for `ArrayAccess` and `IteratorAggregate`.

### Enhancements to JSON serialization:
* Added `@return array<string, mixed>` annotations to `jsonSerialize` methods in `src/Serialization/SerializableResolver.php` and various test files for better type clarity. [[1]](diffhunk://#diff-005a3e03c9641f4f1144ba86b557d75a4b8842b2f1dd576b72b7421426083829R65) [[2]](diffhunk://#diff-c2004c24baeb6be6287e58fbffc464ccce23cfb2cdf5dee3b9fbe855be18d016R18-R28) [[3]](diffhunk://#diff-2bfefe799e2e41ac9e7b19916443919d0e97d117ce9e8ad87468d4f87fe96047R28-R30) [[4]](diffhunk://#diff-fbababd5c29cdbe621f1091f6431d838603ee433f6c32e7c981cc35c4b110553R26-R28) [[5]](diffhunk://#diff-8d63a8f9640e399db517106855475b3e7e5723239f1d16f56ef1e655df20d667R20-R22) and others)
* Improved the handling of nullable and non-required parameters in `jsonSerialize` methods by refactoring lambda functions and simplifying conditions in `src/Serialization/SerializableResolver.php` and test files. [[1]](diffhunk://#diff-005a3e03c9641f4f1144ba86b557d75a4b8842b2f1dd576b72b7421426083829L109-R125) [[2]](diffhunk://#diff-c2004c24baeb6be6287e58fbffc464ccce23cfb2cdf5dee3b9fbe855be18d016R18-R28) [[3]](diffhunk://#diff-b34338d3bd73197f9515fef4a8a1fde4ca03bb8619aa0700df3eb2decac0c54eR19-R29) [[4]](diffhunk://#diff-f5650d00e7521149b01918f2e52ddd5c9c825d5afa28750ccf7b23161db6a823L31-R34) [[5]](diffhunk://#diff-56f8d23701cb23ee40633502cbd2bcd063bfa3e7dc87613b6e31bcfe2f1c4938L33-R39)

### Handling of enum values:
* Added a check to skip `null` values in the `transformEnum` method in `src/Generator/ClassTransformer.php` to ensure only valid enum values are processed.

### Additional minor improvements:
* Added `@return` type annotations for `jsonSerialize` methods in `src/Serialization/ArrayObjectSerialization.php` to improve code documentation.

These changes collectively enhance code readability, maintainability, and correctness, particularly in scenarios involving JSON serialization and type annotations.