### PR TITLE
X php namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ To validate your files, i.e. if the specification matches the generated files, y
 
 Make sure you use the same configuration file as used for the generate command. 
 
+## Namespace
+
+You can specify a custom namespace for a schema or property using the `x-php-namespace` extension.
+This allows you to extend the default namespace configuration.
+
+```yml
+components:
+  schemas:
+    Foo:
+      x-php-namespace: Bar
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: number
+```
+
 ## Types
 
 This library does not support `mixed` type from open-api specification. 

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -70,12 +70,12 @@ class GenerateCommand extends Command
             $parserResult->parsedFiles
         ));
 
-        $namespaces = $this->classGenerator->generate($parserResult->openApi, $configuration);
+        $models = $this->classGenerator->generate($parserResult->openApi, $configuration);
 
-        $this->classWriter->write($configuration, $namespaces);
+        $this->classWriter->write($configuration, $models);
 
-        foreach ($namespaces as $namespace) {
-            $this->outputNamespace($io, $namespace);
+        foreach ($models as $model) {
+            $this->outputNamespace($io, $model->namespace);
         }
 
         $io->success('Finished');

--- a/src/Command/ValidateCommand.php
+++ b/src/Command/ValidateCommand.php
@@ -59,9 +59,9 @@ class ValidateCommand extends Command
 
         $parserResult = $this->parser->parse($configuration);
 
-        $namespaces = $this->classGenerator->generate($parserResult->openApi, $configuration);
+        $models = $this->classGenerator->generate($parserResult->openApi, $configuration);
 
-        $validationResult = $this->validator->validate($configuration, $namespaces);
+        $validationResult = $this->validator->validate($configuration, $models);
 
         $outputFormatter = $this->formatterFactory->create(
             $typedInput->getOption('output-format')

--- a/src/Exception/InvalidInlineObjectException.php
+++ b/src/Exception/InvalidInlineObjectException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Exception;
+
+use Exception;
+
+class InvalidInlineObjectException extends Exception
+{
+    public function __construct(string $parentName, string $propertyName)
+    {
+        parent::__construct(
+            sprintf('Could not transform inline object for property "%s" in class "%s"', $propertyName, $parentName)
+        );
+    }
+}

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -127,6 +127,8 @@ readonly class ClassGenerator
                         $classModel->class->addComment($component->description);
                     }
 
+                    $classModel->imports->copyImports();
+
                     $models[] = $classModel;
                 }
             }

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -71,6 +71,11 @@ readonly class ClassGenerator
                     $classModel->imports->copyImports();
 
                     $models[] = $classModel;
+
+                    foreach ($classModel->getInlineModels() as $inlineModel) {
+                        $inlineModel->imports->copyImports();
+                        $models[] = $inlineModel;
+                    }
                 }
             }
         }
@@ -130,6 +135,11 @@ readonly class ClassGenerator
                     $classModel->imports->copyImports();
 
                     $models[] = $classModel;
+
+                    foreach ($classModel->getInlineModels() as $inlineModel) {
+                        $inlineModel->imports->copyImports();
+                        $models[] = $inlineModel;
+                    }
                 }
             }
         }

--- a/src/Generator/TypeResolver.php
+++ b/src/Generator/TypeResolver.php
@@ -48,7 +48,7 @@ readonly class TypeResolver
 
             return new ClassReference(
                 $schemaWithName->openApiType,
-                $this->namespaceResolver->resolveNamespace($schemaWithName->openApiType)
+                $this->namespaceResolver->resolveNamespace($schemaWithName->openApiType, $schemaWithName->schema)
                     ->resolveName($schemaWithName->name)
             );
         }

--- a/src/Model/ClassModel.php
+++ b/src/Model/ClassModel.php
@@ -7,12 +7,31 @@ namespace Reinfi\OpenApiModels\Model;
 use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\PhpNamespace;
 
-readonly class ClassModel
+class ClassModel
 {
+    /**
+     * @var ClassModel[]
+     */
+    private array $inlineModels = [];
+
     public function __construct(
-        public PhpNamespace $namespace,
-        public ClassLike $class,
-        public Imports $imports,
+        public readonly string $className,
+        public readonly PhpNamespace $namespace,
+        public readonly ClassLike $class,
+        public readonly Imports $imports,
     ) {
+    }
+
+    /**
+     * @return ClassModel[]
+     */
+    public function getInlineModels(): array
+    {
+        return $this->inlineModels;
+    }
+
+    public function addInlineModel(self $classModel): void
+    {
+        $this->inlineModels[] = $classModel;
     }
 }

--- a/src/Model/ClassModel.php
+++ b/src/Model/ClassModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reinfi\OpenApiModels\Model;
+
+use Nette\PhpGenerator\ClassLike;
+use Nette\PhpGenerator\PhpNamespace;
+
+readonly class ClassModel
+{
+    public function __construct(
+        public PhpNamespace $namespace,
+        public ClassLike $class,
+        public Imports $imports,
+    ) {
+    }
+}

--- a/src/Model/ClassModel.php
+++ b/src/Model/ClassModel.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Reinfi\OpenApiModels\Model;
 
-use Nette\PhpGenerator\ClassLike;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\EnumType;
 use Nette\PhpGenerator\PhpNamespace;
 
 class ClassModel
@@ -17,7 +18,7 @@ class ClassModel
     public function __construct(
         public readonly string $className,
         public readonly PhpNamespace $namespace,
-        public readonly ClassLike $class,
+        public readonly ClassType|EnumType $class,
         public readonly Imports $imports,
     ) {
     }

--- a/src/Model/Imports.php
+++ b/src/Model/Imports.php
@@ -29,6 +29,14 @@ class Imports
         }
     }
 
+    /**
+     * @return string[]
+     */
+    public function getImports(): array
+    {
+        return $this->imports;
+    }
+
     public function copyImports(): void
     {
         foreach ($this->imports as $import) {

--- a/src/Validate/Validator.php
+++ b/src/Validate/Validator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Reinfi\OpenApiModels\Validate;
 
-use Nette\PhpGenerator\PhpNamespace;
 use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Model\ClassModel;
 use Reinfi\OpenApiModels\Writer\FileNameResolver;
 use Reinfi\OpenApiModels\Writer\SingleNamespaceResolver;
 use Reinfi\OpenApiModels\Writer\TemplateResolver;
@@ -20,13 +20,14 @@ class Validator
     }
 
     /**
-     * @param array<string, PhpNamespace> $namespaces
+     * @param ClassModel[] $models
      */
-    public function validate(Configuration $configuration, array $namespaces): ValidationResult
+    public function validate(Configuration $configuration, array $models): ValidationResult
     {
         $result = new ValidationResult();
 
-        foreach ($namespaces as $namespace) {
+        foreach ($models as $model) {
+            $namespace = $model->namespace;
             foreach ($namespace->getClasses() as $class) {
                 if ($class->getName() === null) {
                     continue;

--- a/src/Writer/ClassWriter.php
+++ b/src/Writer/ClassWriter.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Writer;
 
 use DirectoryIterator;
-use Nette\PhpGenerator\PhpNamespace;
 use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Model\ClassModel;
 
 readonly class ClassWriter
 {
@@ -18,15 +18,16 @@ readonly class ClassWriter
     }
 
     /**
-     * @param array<string, PhpNamespace> $namespaces
+     * @param ClassModel[] $models
      */
-    public function write(Configuration $configuration, array $namespaces): void
+    public function write(Configuration $configuration, array $models): void
     {
         if ($configuration->clearOutputDirectory) {
             $this->clearOutputDirectory($configuration->outputPath);
         }
 
-        foreach ($namespaces as $namespace) {
+        foreach ($models as $model) {
+            $namespace = $model->namespace;
             foreach ($namespace->getClasses() as $class) {
                 if ($class->getName() === null) {
                     continue;

--- a/src/Writer/ClassWriter.php
+++ b/src/Writer/ClassWriter.php
@@ -28,21 +28,20 @@ readonly class ClassWriter
 
         foreach ($models as $model) {
             $namespace = $model->namespace;
-            foreach ($namespace->getClasses() as $class) {
-                if ($class->getName() === null) {
-                    continue;
-                }
-
-                $filePath = $this->fileNameResolver->resolve($configuration, $namespace, $class);
-
-                if (! is_dir(dirname($filePath))) {
-                    mkdir(dirname($filePath));
-                }
-
-                $classOnlyNamespace = $this->singleNamespaceResolver->resolve($namespace, $class);
-
-                file_put_contents($filePath, $this->templateResolver->resolve($classOnlyNamespace));
+            $class = $model->class;
+            if ($class->getName() === null) {
+                continue;
             }
+
+            $filePath = $this->fileNameResolver->resolve($configuration, $namespace, $class);
+
+            if (! is_dir(dirname($filePath))) {
+                mkdir(dirname($filePath));
+            }
+
+            $classOnlyNamespace = $this->singleNamespaceResolver->resolve($namespace, $class);
+
+            file_put_contents($filePath, $this->templateResolver->resolve($classOnlyNamespace));
         }
     }
 

--- a/src/Writer/FileNameResolver.php
+++ b/src/Writer/FileNameResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Writer;
 
 use Nette\PhpGenerator\ClassLike;
-use Nette\PhpGenerator\Helpers;
 use Nette\PhpGenerator\PhpNamespace;
 use Reinfi\OpenApiModels\Configuration\Configuration;
 
@@ -13,11 +12,28 @@ class FileNameResolver
 {
     public function resolve(Configuration $configuration, PhpNamespace $namespace, ClassLike $class): string
     {
-        $namespaceShortName = Helpers::extractShortName($namespace->getName());
-        $outputDirectoryWithNamespace = sprintf('%s/%s', $configuration->outputPath, $namespaceShortName);
+        $fullNamespace = $namespace->getName();
+        $baseNamespace = rtrim($configuration->namespace, '\\');
+
+        // Remove base namespace from the full namespace.
+        if (str_starts_with($fullNamespace, $baseNamespace)) {
+            $subNamespace = substr($fullNamespace, strlen($baseNamespace));
+        } else {
+            $subNamespace = $fullNamespace;
+        }
+
+        // Clean up leading/trailing backslashes and convert to directory structure.
+        $subNamespace = trim($subNamespace, '\\');
+        $subNamespacePath = $subNamespace !== '' ? str_replace('\\', DIRECTORY_SEPARATOR, $subNamespace) : '';
+
+        // Build the output directory path.
+        $outputDirectory = rtrim($configuration->outputPath, DIRECTORY_SEPARATOR);
+        $outputDirectoryWithNamespace = $subNamespacePath !== ''
+            ? $outputDirectory . DIRECTORY_SEPARATOR . $subNamespacePath
+            : $outputDirectory;
 
         if (! is_dir($outputDirectoryWithNamespace)) {
-            mkdir($outputDirectoryWithNamespace);
+            mkdir($outputDirectoryWithNamespace, recursive: true);
         }
 
         return sprintf('%s/%s.php', $outputDirectoryWithNamespace, $class->getName());

--- a/test/Acceptance/ExpectedClasses/Schema/Test/TestNamespace.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test/TestNamespace.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema\Test;
+
+/**
+ * Test object to be in a different namespace
+ */
+readonly class TestNamespace
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/TestPropertyNamespace.php
+++ b/test/Acceptance/ExpectedClasses/Schema/TestPropertyNamespace.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+use Api\Schema\Test\TestNamespace;
+
+readonly class TestPropertyNamespace
+{
+    public function __construct(
+        public TestNamespace $test,
+    ) {
+    }
+}

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -48,7 +48,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer = $this->createMock(ClassTransformer::class);
@@ -94,7 +94,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer = $this->createMock(ClassTransformer::class);
@@ -140,7 +140,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer = $this->createMock(ClassTransformer::class);
@@ -186,7 +186,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer = $this->createMock(ClassTransformer::class);
@@ -239,7 +239,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer->expects($this->once())
@@ -322,7 +322,7 @@ class ClassGeneratorTest extends TestCase
 
         $namespace = new PhpNamespace('Test');
         $classModel = $this->getMockBuilder(ClassModel::class)
-            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->setConstructorArgs(['Test', $namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
             ->getMock();
 
         $transformer = $this->createMock(ClassTransformer::class);

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Test\Generator;
 
 use DG\BypassFinals;
-use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use openapiphp\openapi\spec\OpenApi;
 use openapiphp\openapi\spec\Reference;
@@ -17,6 +16,8 @@ use Reinfi\OpenApiModels\Generator\ClassGenerator;
 use Reinfi\OpenApiModels\Generator\ClassTransformer;
 use Reinfi\OpenApiModels\Generator\NamespaceResolver;
 use Reinfi\OpenApiModels\Generator\OpenApiType;
+use Reinfi\OpenApiModels\Model\ClassModel;
+use Reinfi\OpenApiModels\Model\Imports;
 
 class ClassGeneratorTest extends TestCase
 {
@@ -28,7 +29,6 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesClassesFromOpenApi(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Schema');
 
         $openApi = new OpenApi([
             'components' => [
@@ -46,24 +46,26 @@ class ClassGeneratorTest extends TestCase
             ],
         ]);
 
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->exactly(2))
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::Schemas,
                 self::callback(static fn (string $name): bool => in_array($name, ['Test1', 'Test2'], true)),
                 self::isInstanceOf(Schema::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Schemas)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -73,7 +75,6 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesRequestBodies(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('RequestBody');
 
         $openApi = new OpenApi([
             'components' => [
@@ -91,24 +92,26 @@ class ClassGeneratorTest extends TestCase
             ],
         ]);
 
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::RequestBodies,
                 'Test1',
                 self::isInstanceOf(Schema::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::RequestBodies)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -118,7 +121,6 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesResponses(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -136,24 +138,26 @@ class ClassGeneratorTest extends TestCase
             ],
         ]);
 
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::Responses,
                 'Test1',
                 self::isInstanceOf(Schema::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Responses)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -163,7 +167,6 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesReferenceClasses(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -181,24 +184,26 @@ class ClassGeneratorTest extends TestCase
             ],
         ]);
 
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::Responses,
                 'Test1',
                 self::isInstanceOf(Reference::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Responses)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -208,7 +213,6 @@ class ClassGeneratorTest extends TestCase
     public function testItGeneratesOnlyJsonSchema(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -232,23 +236,26 @@ class ClassGeneratorTest extends TestCase
         ]);
 
         $transformer = $this->createMock(ClassTransformer::class);
+
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer->expects($this->once())
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::Responses,
                 'Test1',
                 self::isInstanceOf(Schema::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Responses)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -261,7 +268,6 @@ class ClassGeneratorTest extends TestCase
         self::expectExceptionMessage('Only "application/json" is supported as media type, found: application/xml');
 
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -287,9 +293,6 @@ class ClassGeneratorTest extends TestCase
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Responses)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 
@@ -299,7 +302,6 @@ class ClassGeneratorTest extends TestCase
     public function testItSetsCommentIfTopLevelHasDescription(): void
     {
         $configuration = new Configuration([], '', '');
-        $namespace = new PhpNamespace('Response');
 
         $openApi = new OpenApi([
             'components' => [
@@ -318,24 +320,26 @@ class ClassGeneratorTest extends TestCase
             ],
         ]);
 
+        $namespace = new PhpNamespace('Test');
+        $classModel = $this->getMockBuilder(ClassModel::class)
+            ->setConstructorArgs([$namespace, $namespace->addClass('Test'), $this->createMock(Imports::class)])
+            ->getMock();
+
         $transformer = $this->createMock(ClassTransformer::class);
         $transformer->expects($this->once())
             ->method('transform')
             ->with(
                 $configuration,
                 $openApi,
+                OpenApiType::Responses,
                 'Test1',
                 self::isInstanceOf(Schema::class),
-                $namespace
-            )->willReturn(new ClassType());
+            )->willReturn($classModel);
 
         $namespaceResolver = $this->createMock(NamespaceResolver::class);
         $namespaceResolver->expects($this->once())
             ->method('initialize')
             ->with($configuration);
-        $namespaceResolver->expects($this->once())
-            ->method('resolveNamespace')
-            ->with(OpenApiType::Responses)->willReturn($namespace);
 
         $generator = new ClassGenerator($transformer, $namespaceResolver);
 

--- a/test/Generator/ClassTransformerTest.php
+++ b/test/Generator/ClassTransformerTest.php
@@ -31,6 +31,7 @@ use Reinfi\OpenApiModels\Generator\TypeResolver;
 use Reinfi\OpenApiModels\Generator\Types;
 use Reinfi\OpenApiModels\Model\AllOfType;
 use Reinfi\OpenApiModels\Model\ArrayType;
+use Reinfi\OpenApiModels\Model\ClassModel;
 use Reinfi\OpenApiModels\Model\Imports;
 use Reinfi\OpenApiModels\Model\ScalarType;
 use Reinfi\OpenApiModels\Model\SchemaWithName;
@@ -2323,7 +2324,7 @@ class ClassTransformerTest extends TestCase
 
         $dictionaryResolver->expects($this->once())
             ->method('resolve')
-            ->with($namespace, 'Test', self::isInstanceOf(ClassType::class), 'string');
+            ->with(self::isInstanceOf(ClassModel::class), 'Test', self::isInstanceOf(ClassType::class), 'string');
 
         $serializableResolver->expects($this->once())
             ->method('resolve')

--- a/test/Generator/DictionaryResolverTest.php
+++ b/test/Generator/DictionaryResolverTest.php
@@ -10,6 +10,8 @@ use Nette\PhpGenerator\PhpNamespace;
 use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Generator\DictionaryResolver;
 use Reinfi\OpenApiModels\Model\ArrayType;
+use Reinfi\OpenApiModels\Model\ClassModel;
+use Reinfi\OpenApiModels\Model\Imports;
 
 class DictionaryResolverTest extends TestCase
 {
@@ -21,7 +23,9 @@ class DictionaryResolverTest extends TestCase
         $class = $namespace->addClass('Test');
         $class->addMethod('__construct');
 
-        $resolver->resolve($namespace, 'Test', $class, 'string');
+        $classModel = new ClassModel('Test', $namespace, $class, new Imports($namespace));
+
+        $resolver->resolve($classModel, 'Test', $class, 'string');
 
         $constructor = $class->getMethod('__construct');
 
@@ -41,7 +45,9 @@ class DictionaryResolverTest extends TestCase
         $class = $namespace->addClass('Test');
         $class->addMethod('__construct');
 
-        $resolver->resolve($namespace, 'Test', $class, 'string');
+        $classModel = new ClassModel('Test', $namespace, $class, new Imports($namespace));
+
+        $resolver->resolve($classModel, 'Test', $class, 'string');
 
         self::assertTrue($class->hasProperty('dictionaries'));
 
@@ -61,7 +67,9 @@ class DictionaryResolverTest extends TestCase
         $class = $namespace->addClass('Test');
         $class->addMethod('__construct');
 
-        $resolver->resolve($namespace, 'Test', $class, 'string');
+        $classModel = new ClassModel('Test', $namespace, $class, new Imports($namespace));
+
+        $resolver->resolve($classModel, 'Test', $class, 'string');
 
         $classes = $namespace->getClasses();
 
@@ -92,7 +100,9 @@ class DictionaryResolverTest extends TestCase
         $class = $namespace->addClass('Test');
         $class->addMethod('__construct');
 
-        $resolver->resolve($namespace, 'Test', $class, new ArrayType('string', false, '@var string[] $value'));
+        $classModel = new ClassModel('Test', $namespace, $class, new Imports($namespace));
+
+        $resolver->resolve($classModel, 'Test', $class, new ArrayType('string', false, '@var string[] $value'));
 
         $classes = $namespace->getClasses();
 

--- a/test/Validate/ValidatorTest.php
+++ b/test/Validate/ValidatorTest.php
@@ -10,6 +10,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
 use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Model\ClassModel;
+use Reinfi\OpenApiModels\Model\Imports;
 use Reinfi\OpenApiModels\Validate\Validator;
 use Reinfi\OpenApiModels\Writer\FileNameResolver;
 use Reinfi\OpenApiModels\Writer\SingleNamespaceResolver;
@@ -47,7 +49,7 @@ class ValidatorTest extends TestCase
         $this->outputDir->addChild($schemaDirectory);
 
         $namespace = new PhpNamespace('Schema');
-        $namespace->addClass('Foo');
+        $class = $namespace->addClass('Foo');
 
         $fileNameResolver = $this->createMock(FileNameResolver::class);
         $singleNamespaceResolver = $this->createMock(SingleNamespaceResolver::class);
@@ -68,7 +70,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            'Schema' => $namespace,
+            new ClassModel($namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertTrue($result->isValid());
@@ -78,7 +80,7 @@ class ValidatorTest extends TestCase
     public function testItIsNotValidIfClassDoesNotExists(): void
     {
         $namespace = new PhpNamespace('Schema');
-        $namespace->addClass('Foo');
+        $class = $namespace->addClass('Foo');
 
         $fileNameResolver = $this->createMock(FileNameResolver::class);
         $singleNamespaceResolver = $this->createMock(SingleNamespaceResolver::class);
@@ -98,7 +100,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            'Schema' => $namespace,
+            new ClassModel($namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertFalse($result->isValid());
@@ -112,7 +114,7 @@ class ValidatorTest extends TestCase
         $this->outputDir->addChild($schemaDirectory);
 
         $namespace = new PhpNamespace('Schema');
-        $namespace->addClass('Foo');
+        $class = $namespace->addClass('Foo');
 
         $fileNameResolver = $this->createMock(FileNameResolver::class);
         $singleNamespaceResolver = $this->createMock(SingleNamespaceResolver::class);
@@ -133,7 +135,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            'Schema' => $namespace,
+            new ClassModel($namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertFalse($result->isValid());

--- a/test/Validate/ValidatorTest.php
+++ b/test/Validate/ValidatorTest.php
@@ -70,7 +70,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            new ClassModel($namespace, $class, new Imports($namespace)),
+            new ClassModel('Foo', $namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertTrue($result->isValid());
@@ -100,7 +100,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            new ClassModel($namespace, $class, new Imports($namespace)),
+            new ClassModel('Foo', $namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertFalse($result->isValid());
@@ -135,7 +135,7 @@ class ValidatorTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $result = $validator->validate($configuration, [
-            new ClassModel($namespace, $class, new Imports($namespace)),
+            new ClassModel('Foo', $namespace, $class, new Imports($namespace)),
         ]);
 
         self::assertFalse($result->isValid());

--- a/test/Writer/ClassWriterTest.php
+++ b/test/Writer/ClassWriterTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Reinfi\OpenApiModels\Test\Writer;
 
 use DG\BypassFinals;
+use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
 use PHPUnit\Framework\TestCase;
 use Reinfi\OpenApiModels\Configuration\Configuration;
+use Reinfi\OpenApiModels\Model\ClassModel;
+use Reinfi\OpenApiModels\Model\Imports;
 use Reinfi\OpenApiModels\Writer\ClassWriter;
 use Reinfi\OpenApiModels\Writer\FileNameResolver;
 use Reinfi\OpenApiModels\Writer\SingleNamespaceResolver;
@@ -53,15 +56,18 @@ class ClassWriterTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $firstNamespace = new PhpNamespace('Schema');
-        $firstNamespace->addClass('ClassFirst');
+        $firstClass = new ClassType('ClassFirst');
+        $firstNamespace->add($firstClass);
+        $firstImports = new Imports($firstNamespace);
+        $firstModel = new ClassModel($firstNamespace, $firstClass, $firstImports);
 
         $secondNamespace = new PhpNamespace('Response');
-        $secondNamespace->addClass('ClassSecond');
+        $secondClass = new ClassType('ClassSecond');
+        $secondNamespace->add($secondClass);
+        $secondImports = new Imports($secondNamespace);
+        $secondModel = new ClassModel($secondNamespace, $secondClass, $secondImports);
 
-        $writer->write($configuration, [
-            'schemas' => $firstNamespace,
-            'responses' => $secondNamespace,
-        ]);
+        $writer->write($configuration, [$firstModel, $secondModel]);
 
         $children = $this->outputDir->getChildren();
         self::assertCount(2, $children, 'two directories should be created');
@@ -96,11 +102,12 @@ class ClassWriterTest extends TestCase
         $configuration = new Configuration([], $this->outputDir->url(), '');
 
         $namespace = new PhpNamespace('Schema');
-        $namespace->addClass('ClassFirst');
+        $class = new ClassType('ClassFirst');
+        $namespace->add($class);
+        $imports = new Imports($namespace);
+        $model = new ClassModel($namespace, $class, $imports);
 
-        $writer->write($configuration, [
-            'schemas' => $namespace,
-        ]);
+        $writer->write($configuration, [$model]);
 
         $schemaDirectory = $this->outputDir->getChild('Schema');
         self::assertInstanceOf(vfsStreamDirectory::class, $schemaDirectory);

--- a/test/Writer/ClassWriterTest.php
+++ b/test/Writer/ClassWriterTest.php
@@ -59,13 +59,13 @@ class ClassWriterTest extends TestCase
         $firstClass = new ClassType('ClassFirst');
         $firstNamespace->add($firstClass);
         $firstImports = new Imports($firstNamespace);
-        $firstModel = new ClassModel($firstNamespace, $firstClass, $firstImports);
+        $firstModel = new ClassModel('ClassFirst', $firstNamespace, $firstClass, $firstImports);
 
         $secondNamespace = new PhpNamespace('Response');
         $secondClass = new ClassType('ClassSecond');
         $secondNamespace->add($secondClass);
         $secondImports = new Imports($secondNamespace);
-        $secondModel = new ClassModel($secondNamespace, $secondClass, $secondImports);
+        $secondModel = new ClassModel('ClassSecond', $secondNamespace, $secondClass, $secondImports);
 
         $writer->write($configuration, [$firstModel, $secondModel]);
 
@@ -105,7 +105,7 @@ class ClassWriterTest extends TestCase
         $class = new ClassType('ClassFirst');
         $namespace->add($class);
         $imports = new Imports($namespace);
-        $model = new ClassModel($namespace, $class, $imports);
+        $model = new ClassModel('ClassFirst', $namespace, $class, $imports);
 
         $writer->write($configuration, [$model]);
 

--- a/test/Writer/FileNameResolverTest.php
+++ b/test/Writer/FileNameResolverTest.php
@@ -48,4 +48,19 @@ class FileNameResolverTest extends TestCase
 
         self::assertInstanceOf(vfsStreamDirectory::class, $this->outputDir->getChild('Schema'));
     }
+
+    public function testItResolvesWithBaseNamespaceAndNestedSubNamespace(): void
+    {
+        $resolver = new FileNameResolver();
+
+        $configuration = new Configuration([], $this->outputDir->url(), 'Base');
+        $namespace = new PhpNamespace('Base\\Sub\\Nested');
+        $class = $namespace->addClass('MyClass');
+
+        $expectedPath = sprintf('%s/Sub/Nested/MyClass.php', $this->outputDir->url());
+        $actualPath = $resolver->resolve($configuration, $namespace, $class);
+
+        self::assertEquals($expectedPath, $actualPath);
+        self::assertInstanceOf(vfsStreamDirectory::class, $this->outputDir->getChild('Sub') ->getChild('Nested'));
+    }
 }

--- a/test/Writer/FileNameResolverTest.php
+++ b/test/Writer/FileNameResolverTest.php
@@ -61,6 +61,8 @@ class FileNameResolverTest extends TestCase
         $actualPath = $resolver->resolve($configuration, $namespace, $class);
 
         self::assertEquals($expectedPath, $actualPath);
-        self::assertInstanceOf(vfsStreamDirectory::class, $this->outputDir->getChild('Sub') ->getChild('Nested'));
+        $subDirectory = $this->outputDir->getChild('Sub');
+        self::assertInstanceOf(vfsStreamDirectory::class, $subDirectory);
+        self::assertInstanceOf(vfsStreamDirectory::class, $subDirectory->getChild('Nested'));
     }
 }

--- a/test/config/acceptance-test.php
+++ b/test/config/acceptance-test.php
@@ -6,6 +6,6 @@ return [
     'paths' => [__DIR__ . '/../spec/acceptance.yml'],
     'outputPath' => __DIR__ . '/../output',
     'namespace' => 'Api',
-    'clearOutputDirectory' => true,
+    'clearOutputDirectory' => false,
     'dateTimeAsObject' => true,
 ];

--- a/test/config/acceptance-test.php
+++ b/test/config/acceptance-test.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 return [
-    #'paths' => [__DIR__ . '/../spec/chatbot.yaml'],
     'paths' => [__DIR__ . '/../spec/acceptance.yml'],
     'outputPath' => __DIR__ . '/../output',
     'namespace' => 'Api',
-    'clearOutputDirectory' => false,
+    'clearOutputDirectory' => true,
     'dateTimeAsObject' => true,
 ];

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -262,6 +262,16 @@ components:
         items:
           type: string
 
+    TestNamespace:
+      type: object
+      x-php-namespace: Test
+      description: Test object to be in a different namespace
+      required:
+        - id
+      properties:
+        id:
+          type: number
+
     NullableDate:
       type: string
       format: date
@@ -313,6 +323,14 @@ components:
         - A wonderful red like a rose
         - Just as green as an apple
         - Like the white snow on the mountains
+
+    ColorNamespace:
+      type: string
+      x-php-namespace: Enums
+      enum:
+        - red
+        - green
+        - white
 
     Test7OrTest8:
       oneOf:

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -262,6 +262,14 @@ components:
         items:
           type: string
 
+    TestPropertyNamespace:
+      type: object
+      required:
+        - test
+      properties:
+        test:
+          $ref: '#/components/schemas/TestNamespace'
+
     TestNamespace:
       type: object
       x-php-namespace: Test


### PR DESCRIPTION
Finally support for `x-php-namespace` although it is not supported officially in the OpenApi specification I would like to add support for it. 

By this you can structure your models way better than into one big folder.