### PR TITLE
Support nullable enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ components:
 This library does not support `mixed` type from open-api specification. 
 Therefore, you always have to set a type in your specification.
 
+## Enum
+
+Enums are converted to native PHP enums. If your property should be nullable you must set the
+property itself nullable and also add null as enum case value.
+
+```yml
+components:
+  schemas:
+    Test1:
+      type: object
+      required:
+        - state
+      properties:
+        state:
+          type: string
+          nullable: true
+          enum: 
+            - Good
+            - Bad
+            - null
+```
+
+For more information about nullable enums, see
+the [Swagger documentation](https://swagger.io/docs/specification/v3_0/data-models/enums/#nullable-enums).
+
 ## Date or DateTime
 
 The following schema has date/date-time properties.

--- a/src/Generator/ClassTransformer.php
+++ b/src/Generator/ClassTransformer.php
@@ -356,9 +356,10 @@ readonly class ClassTransformer
         // https://swagger.io/docs/specification/v3_0/data-models/enums/#nullable-enums
         $nullable = $schema->nullable && in_array(null, $schema->enum, true);
 
-        if ($schema->nullable && !in_array(null, $schema->enum, true)) {
+        if ($schema->nullable && ! in_array(null, $schema->enum, true)) {
             throw new InvalidEnumSchema(
-                $enumName, 'Defining a nullable enum requires to have the "null" value present in the enum values'
+                $enumName,
+                'Defining a nullable enum requires to have the "null" value present in the enum values'
             );
         }
 
@@ -383,6 +384,13 @@ readonly class ClassTransformer
             }
 
             if (! is_string($enumValue) && ! is_int($enumValue)) {
+                if ($enumValue === null) {
+                    throw new InvalidEnumSchema(
+                        $enumName,
+                        'Defining a nullable enum requires to set the schema nullable'
+                    );
+                }
+
                 throw new InvalidArgumentException(sprintf(
                     'Enum value must be string or integer, got %s',
                     gettype($enumValue)

--- a/test/Acceptance/ExpectedClasses/Schema/Test17NullableEnum.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test17NullableEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+readonly class Test17NullableEnum
+{
+    public function __construct(
+        public ?Test17NullableEnumEnumValue $enumValue,
+    ) {
+    }
+}

--- a/test/Acceptance/ExpectedClasses/Schema/Test17NullableEnumEnumValue.php
+++ b/test/Acceptance/ExpectedClasses/Schema/Test17NullableEnumEnumValue.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Schema;
+
+enum Test17NullableEnumEnumValue: string
+{
+    /** You did it good */
+    case Good = 'good';
+
+    /** Next time you do it better */
+    case Bad = 'bad';
+}

--- a/test/spec/acceptance.yml
+++ b/test/spec/acceptance.yml
@@ -372,6 +372,25 @@ components:
               items:
                 type: integer
 
+    Test17NullableEnum:
+      type: object
+      required:
+        - enumValue
+      properties:
+        enumValue:
+          type: string
+          enum:
+            - null
+            - good
+            - bad
+          nullable: true
+          x-enum-varnames:
+            - Good
+            - Bad
+          x-enum-descriptions:
+            - You did it good
+            - Next time you do it better
+
   requestBodies:
     RequestBody1:
       content:


### PR DESCRIPTION
Solves the issues with #56. Now nullable enums are supported when they are correctly defined. 

If not you will get an exception, this may break current generations.