### PR TITLE
Fix kebab case parameters in PropertyResolver

### DIFF
--- a/src/Generator/PropertyResolver.php
+++ b/src/Generator/PropertyResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\OpenApiModels\Generator;
 
+use Nette\PhpGenerator\Helpers;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PromotedParameter;
 use openapiphp\openapi\spec\Reference;

--- a/src/Generator/PropertyResolver.php
+++ b/src/Generator/PropertyResolver.php
@@ -22,8 +22,8 @@ readonly class PropertyResolver
         bool $required,
         ScalarType|ClassReference|InlineSchemaReference|OneOfReference|Types|string $type,
     ): PromotedParameter {
-        if (!Helpers::isIdentifier($name)) {
-          $name = str_replace('-', '_', $name);
+        if (! Helpers::isIdentifier($name)) {
+            $name = str_replace('-', '_', $name);
         }
 
         $property = $constructor->addPromotedParameter($name);

--- a/src/Generator/PropertyResolver.php
+++ b/src/Generator/PropertyResolver.php
@@ -21,6 +21,10 @@ readonly class PropertyResolver
         bool $required,
         ScalarType|ClassReference|InlineSchemaReference|OneOfReference|Types|string $type,
     ): PromotedParameter {
+        if (!Helpers::isIdentifier($name)) {
+          $name = str_replace('-', '_', $name);
+        }
+
         $property = $constructor->addPromotedParameter($name);
 
         if (is_string($type)) {

--- a/test/Generator/PropertyResolverTest.php
+++ b/test/Generator/PropertyResolverTest.php
@@ -150,4 +150,26 @@ class PropertyResolverTest extends TestCase
             self::assertTrue($parameter->isNullable());
         }
     }
+
+    public function testItConvertsKebabCaseNameToValidIdentifier(): void
+    {
+        $constructor = new Method('__construct');
+        $resolver = new PropertyResolver();
+
+        $originalName = 'my-prop';
+        $schema = new Schema([
+            'nullable' => false,
+        ]);
+
+        $parameter = $resolver->resolve($constructor, $originalName, $schema, true, 'string');
+
+        self::assertSame('my_prop', $parameter->getName(), 'Kebab-case name should be converted to underscore');
+        self::assertSame('string', $parameter->getType());
+        self::assertFalse($parameter->isNullable());
+
+        // Ensure the constructor now contains a promoted parameter with the converted name
+        $parameters = $constructor->getParameters();
+        self::assertArrayHasKey('my_prop', $parameters);
+        self::assertArrayNotHasKey('my-prop', $parameters);
+    }
 }


### PR DESCRIPTION
A kebab cased property like `document-label` is not an acceptable PHP property, so we need to convert it to something that is acceptable.

This patch converts it to snake case, the easiest adaption.